### PR TITLE
chore: remove redundant sync preamble from all mode files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Removed
+- Redundant "Step 0 — Sync workspace" block from all mode files (`fix.md`, `force-approve.md`, `implement.md`, `merge.md`, `review.md`, `review-round2.md`); `ralph.sh` already syncs the worktree before building any prompt (#2)

--- a/modes/fix.md
+++ b/modes/fix.md
@@ -4,14 +4,6 @@ PR #{{PR_NUMBER}} in `{{REPO}}` has a `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` c
 
 Read `ralph/project.md` for the build and test commands.
 
-## Step 0 — Sync workspace
-
-Before doing anything else:
-
-- Run `git fetch origin`
-- Run `git reset --hard origin/main`
-  (The worktree runs in detached HEAD mode — do not run `git checkout main`.)
-
 ## Step 1 — Read the review
 
 Use `gh pr view {{PR_NUMBER}} --repo {{REPO}} --comments` or GitHub MCP tools to read the REQUEST_CHANGES comment. Read **every** issue listed — you must address all of them in one pass, not just some.

--- a/modes/force-approve.md
+++ b/modes/force-approve.md
@@ -2,14 +2,6 @@
 
 PR #{{PR_NUMBER}} in `{{REPO}}` has already had two rounds of review and fixes. Approve it unconditionally.
 
-## Step 0 — Sync workspace
-
-Before doing anything else:
-
-- Run `git fetch origin`
-- Run `git reset --hard origin/main`
-  (The worktree runs in detached HEAD mode — do not run `git checkout main`.)
-
 ## Step 1 — Approve
 
 Post this comment:

--- a/modes/implement.md
+++ b/modes/implement.md
@@ -4,14 +4,6 @@ You are implementing GitHub issue #{{ISSUE_NUMBER}} in the `{{REPO}}` repository
 
 Read `ralph/project.md` for the build and test commands.
 
-## Step 0 — Sync workspace
-
-Before doing anything else:
-
-- Run `git fetch origin`
-- Run `git reset --hard origin/main`
-  (The worktree runs in detached HEAD mode — do not run `git checkout main`.)
-
 ## Step 1 — Get up to speed
 
 - Run `git log --oneline -10` to see recent commits.

--- a/modes/merge.md
+++ b/modes/merge.md
@@ -4,14 +4,6 @@ PR #{{PR_NUMBER}} in `{{REPO}}` has been approved. Merge it.
 
 Read `ralph/project.md` for the build and test commands.
 
-## Step 0 — Sync workspace
-
-Before doing anything else:
-
-- Run `git fetch origin`
-- Run `git reset --hard origin/main`
-  (The worktree runs in detached HEAD mode — do not run `git checkout main`.)
-
 ## Step 1 — Verify CI
 
 Check that all CI checks have passed:

--- a/modes/review-round2.md
+++ b/modes/review-round2.md
@@ -4,14 +4,6 @@ You are verifying that round-1 review issues have been fixed on PR #{{PR_NUMBER}
 
 Read `ralph/project.md` for the build and test commands.
 
-## Step 0 — Sync workspace
-
-Before doing anything else:
-
-- Run `git fetch origin`
-- Run `git reset --hard origin/main`
-  (The worktree runs in detached HEAD mode — do not run `git checkout main`.)
-
 ## Step 1 — Find the original issues
 
 Use `gh pr view {{PR_NUMBER}} --repo {{REPO}} --comments` or GitHub MCP tools to read the PR comment timeline. Find the `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` comment and note every issue it listed.

--- a/modes/review.md
+++ b/modes/review.md
@@ -4,14 +4,6 @@ You are reviewing PR #{{PR_NUMBER}} in the `{{REPO}}` repository.
 
 Read `ralph/project.md` for the build and test commands.
 
-## Step 0 — Sync workspace
-
-Before doing anything else:
-
-- Run `git fetch origin`
-- Run `git reset --hard origin/main`
-  (The worktree runs in detached HEAD mode — do not run `git checkout main`.)
-
 ## Step 1 — Review
 
 Delegate the review to a sub-agent. Do not review the code yourself.


### PR DESCRIPTION
Closes #2

## What was implemented

Removed the duplicated `## Step 0 — Sync workspace` block from all six mode files:
- `modes/fix.md`
- `modes/force-approve.md`
- `modes/implement.md`
- `modes/merge.md`
- `modes/review.md`
- `modes/review-round2.md`

`ralph.sh` already syncs the worktree in `determine_mode()` with `git fetch origin && git reset --hard origin/main` before any prompt is built or run, so asking the AI to repeat this step was redundant.

## Notes

No step renumbering was needed — removing Step 0 leaves the existing Step 1, 2, … numbering intact and correct.