### PR TITLE
feat: issue and PR filtering for PRD mode and standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Issue filter in PRD mode uses `--label "prd/<label>"` to scope to the current PRD; excludes the PRD issue itself (`prd` label) and `blocked` issues (#7)
 - Issue filter in standalone mode additionally excludes any issue carrying a `prd/*` label (#7)
 
-### Changed
-- Worktree and `determine_mode()` sync now use `origin/$FEATURE_BRANCH` instead of always `origin/main` (#6)
-
 ### Removed
 - `permanent_issue` removed from `project.toml`, `project.example.toml`, `ralph.sh` parsing, and `build_prompt()` substitution (#6)
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -111,17 +111,19 @@ fi
 # In PRD mode, validate that either prd/* issues exist or the feature branch already
 # exists on origin. If neither is true, the label is almost certainly a typo.
 if [[ -n "$FEATURE_LABEL" ]]; then
-  PRD_ISSUE_COUNT=$(gh issue list --repo "$REPO" --state open \
-    --label "$FEATURE_LABEL" \
-    --json number --jq 'length' \
-    < /dev/null 2>/dev/null || echo "0")
-
-  if [[ "$PRD_ISSUE_COUNT" -eq 0 ]]; then
-    if ! git -C "$GIT_ROOT" ls-remote --exit-code --heads origin "$FEATURE_BRANCH" > /dev/null 2>&1; then
-      echo "Error: No open issues with label '${FEATURE_LABEL}' found, and branch 'origin/${FEATURE_BRANCH}' does not exist."
-      echo "Check that --label matches an existing PRD label, or create the feature branch first."
-      exit 1
+  if PRD_ISSUE_COUNT=$(gh issue list --repo "$REPO" --state open \
+      --label "$FEATURE_LABEL" \
+      --json number --jq 'length' \
+      < /dev/null 2>/dev/null); then
+    if [[ "$PRD_ISSUE_COUNT" -eq 0 ]]; then
+      if ! git -C "$GIT_ROOT" ls-remote --exit-code --heads origin "$FEATURE_BRANCH" > /dev/null 2>&1; then
+        echo "Error: No open issues with label '${FEATURE_LABEL}' found, and branch 'origin/${FEATURE_BRANCH}' does not exist."
+        echo "Check that --label matches an existing PRD label, or create the feature branch first."
+        exit 1
+      fi
     fi
+  else
+    echo "Warning: Could not reach GitHub API; skipping PRD preflight check."
   fi
 fi
 


### PR DESCRIPTION
Closes #7

## What was implemented

### PR filtering
Added `--base "$FEATURE_BRANCH"` to the `gh pr list` call in `determine_mode()`. Ralph now only sees open PRs that target the current feature branch, ignoring PRs aimed at other branches.

### PRD mode issue filtering
In PRD mode (`--label=foo-widget`), the issue query now passes `--label "prd/foo-widget"` to GitHub, scoping results to only issues belonging to that PRD. The existing jq filter continues to exclude the PRD issue itself (`prd` label) and any `blocked` issues. High-priority-first ordering is preserved within the filtered set.

### Standalone mode issue filtering
In standalone mode (no `--label` flag), the jq filter now additionally excludes any issue carrying a label that starts with `prd/`, so PRD work items are invisible. Issues with `high priority`, plain labels, or no labels remain visible as before.

### Error handling / preflight validation
Added a preflight check (before worktree setup): if `--label=foo-widget` is given but no `prd/foo-widget` issues exist **and** `feat/foo-widget` does not exist on origin, the script prints a helpful diagnostic and exits non-zero.

## Limitations / known rough edges
- The preflight check runs a `gh issue list` API call before the worktree is created. This adds a small latency on startup in PRD mode, but only when both conditions (no issues + no branch) are true does it exit early.
- If all PRD issues are closed/resolved but the feature branch still exists, the preflight passes and Ralph will reach `complete` mode normally.