### PR TITLE
feat(modes): use {{FEATURE_BRANCH}} in implement.md and merge.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - PR filter in `determine_mode()` now includes `--base "$FEATURE_BRANCH"` so only PRs targeting the current feature branch are considered (#7)
 - Issue filter in PRD mode uses `--label "prd/<label>"` to scope to the current PRD; excludes the PRD issue itself (`prd` label) and `blocked` issues (#7)
 - Issue filter in standalone mode additionally excludes any issue carrying a `prd/*` label (#7)
+- `implement.md` instructs Copilot to open PRs against `{{FEATURE_BRANCH}}` instead of `main` (#8)
+- `merge.md` uses `{{FEATURE_BRANCH}}` as the base in all sync, merge, rebase, and downstream PR filter instructions (#8)
 
 ### Removed
 - `permanent_issue` removed from `project.toml`, `project.example.toml`, `ralph.sh` parsing, and `build_prompt()` substitution (#6)

--- a/modes/implement.md
+++ b/modes/implement.md
@@ -50,7 +50,7 @@ If the checks passed:
 
 **Commit** all changes (code + CHANGELOG) together using conventional commits (`feat:`, `fix:`, `chore:`, `refactor:`).
 
-**Open a GitHub PR** from `ralph/issue-{{ISSUE_NUMBER}}` targeting `main`. The PR body should:
+**Open a GitHub PR** from `ralph/issue-{{ISSUE_NUMBER}}` targeting `{{FEATURE_BRANCH}}`. The PR body should:
 - Reference the issue with `Closes #{{ISSUE_NUMBER}}`
 - Summarise what was implemented
 - Note any limitations or known rough edges

--- a/modes/merge.md
+++ b/modes/merge.md
@@ -20,21 +20,21 @@ gh pr checks {{PR_NUMBER}} --repo {{REPO}} < /dev/null
 gh pr merge {{PR_NUMBER}} --repo {{REPO}} --merge < /dev/null
 ```
 
-## Step 3 — Update workspace to new main
+## Step 3 — Update workspace to new `{{FEATURE_BRANCH}}`
 
 ```bash
-git fetch origin && git reset --hard origin/main
+git fetch origin && git reset --hard origin/{{FEATURE_BRANCH}}
 ```
 
 ## Step 4 — Rebase downstream PRs
 
-Find all open `ralph/issue-*` PRs with a PR number greater than {{PR_NUMBER}}. For each, in ascending order:
+Find all open `ralph/issue-*` PRs with a PR number greater than {{PR_NUMBER}} that target `{{FEATURE_BRANCH}}`. For each, in ascending order:
 
 - Note the tip SHA of the just-merged branch (use the PR's merge info or `git log` to find the last commit of that branch).
-- Fetch and rebase the downstream branch onto new main:
+- Fetch and rebase the downstream branch onto new `{{FEATURE_BRANCH}}`:
   ```bash
   git fetch origin ralph/issue-<M>
-  git rebase --onto main <old-tip-sha> ralph/issue-<M>
+  git rebase --onto {{FEATURE_BRANCH}} <old-tip-sha> ralph/issue-<M>
   ```
 - If the rebase succeeds and `{{TEST_CMD}}` passes: `git push --force-with-lease origin ralph/issue-<M>`
 - **If there are conflicts:** attempt to resolve them — read the conflicting files, understand what both sides are doing, and apply the resolution that preserves both sets of changes. Run tests to verify. If tests pass, continue the rebase and push.


### PR DESCRIPTION
Closes #8

## Summary

Updates `implement.md` and `merge.md` to replace hardcoded `main` base-branch references with the `{{FEATURE_BRANCH}}` placeholder. This makes task PRs target the feature branch in PRD mode and `main` in standalone mode — transparently, with no conditional logic in the mode files.

### Changes

- **`implement.md`**: PR open instruction now targets `{{FEATURE_BRANCH}}` instead of `main`
- **`merge.md`**:
  - Step 3 heading and `git reset --hard` sync command use `{{FEATURE_BRANCH}}`
  - Downstream PR search filters by `{{FEATURE_BRANCH}}` as the base branch
  - `git rebase --onto` command uses `{{FEATURE_BRANCH}}`
  - Prose updated from "new main" to "new `{{FEATURE_BRANCH}}`"

### Behaviour

- **Standalone mode** (`{{FEATURE_BRANCH}}` → `main`): rendered prompts are equivalent to before
- **PRD mode** (`{{FEATURE_BRANCH}}` → `feat/<label>`): rendered prompts correctly reference the feature branch