### PR TITLE
feat(gh-comment-fix): prevent gh pr comment stdin hangs across all mode files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Label filtering in `determine_mode()` used jq `contains`, which does substring matching on strings; a label like `prd/feature-branch-workflow` was incorrectly treated as matching `prd` and excluded from the work queue. Replaced with `any(. == "label")` for exact equality matching on all three label checks (`prd`, `blocked`, `high priority`).
 - `merge.md` did not explicitly close the implemented issue after merging. GitHub only auto-closes issues referenced with `Closes #N` when a PR merges into the default branch — merging into a feature branch left the issue open, causing Ralph to loop. Added an explicit `gh issue close` step to `merge.md`.
+- Added `⚠️ Never use gh pr comment --body "..."` ground rule immediately after the opening paragraph in all 7 mode files (`fix.md`, `implement.md`, `merge.md`, `review.md`, `review-round2.md`, `force-approve.md`, `feature-pr.md`) to prevent stdin hangs (#16)
+- Replaced vague CI-failure prose in `merge.md` Step 1 with the full explicit shell template using `--body-file /tmp/ralph-review.md < /dev/null`, matching the pattern in `review.md` and `review-round2.md` (#16)
 
 ### Removed
 - Redundant "Step 0 — Sync workspace" block from all mode files (`fix.md`, `force-approve.md`, `implement.md`, `merge.md`, `review.md`, `review-round2.md`); `ralph.sh` already syncs the worktree before building any prompt (#2)

--- a/modes/feature-pr.md
+++ b/modes/feature-pr.md
@@ -2,6 +2,8 @@
 
 All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been merged into `{{FEATURE_BRANCH}}`. Your job is to open a pull request from `{{FEATURE_BRANCH}}` to `main` for human review.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Verify no existing PR
 
 Check whether a `{{FEATURE_BRANCH}} → main` PR already exists:

--- a/modes/fix.md
+++ b/modes/fix.md
@@ -2,6 +2,8 @@
 
 PR #{{PR_NUMBER}} in `{{REPO}}` has a `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` comment that needs addressing.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Read the review
 
 Use `gh pr view {{PR_NUMBER}} --repo {{REPO}} --comments` or GitHub MCP tools to read the REQUEST_CHANGES comment. Read **every** issue listed — you must address all of them in one pass, not just some.

--- a/modes/force-approve.md
+++ b/modes/force-approve.md
@@ -2,6 +2,8 @@
 
 PR #{{PR_NUMBER}} in `{{REPO}}` has already had two rounds of review and fixes. Approve it unconditionally.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Approve
 
 Post this comment:

--- a/modes/implement.md
+++ b/modes/implement.md
@@ -2,6 +2,8 @@
 
 You are implementing GitHub issue #{{ISSUE_NUMBER}} in the `{{REPO}}` repository.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Get up to speed
 
 - Run `git log --oneline -10` to see recent commits.

--- a/modes/merge.md
+++ b/modes/merge.md
@@ -2,6 +2,8 @@
 
 PR #{{PR_NUMBER}} in `{{REPO}}` has been approved. Merge it.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Verify CI
 
 Check that all CI checks have passed:
@@ -10,9 +12,28 @@ Check that all CI checks have passed:
 gh pr checks {{PR_NUMBER}} --repo {{REPO}} < /dev/null
 ```
 
-- If any check is **failed**: post a `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` comment listing the failing check names, then emit `<promise>STOP</promise>` as your final output.
+- If any check is **failed**: post a `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` comment using the shell template below, then emit `<promise>STOP</promise>` as your final output.
 - If any check is **in progress**: emit `<promise>STOP</promise>` as your final output without posting a comment.
 - Only proceed to Step 2 if all checks have passed.
+
+**CI-failure comment template:**
+
+```bash
+cat > /tmp/ralph-review.md << 'EOF'
+<!-- RALPH-REVIEW: REQUEST_CHANGES -->
+
+The following CI checks failed and must pass before this PR can merge:
+
+- <failing-check-name>
+- <failing-check-name>
+
+Please fix the failures and re-request review.
+
+— Ralph 🤖
+EOF
+gh pr comment {{PR_NUMBER}} --repo {{REPO}} --body-file /tmp/ralph-review.md < /dev/null
+rm /tmp/ralph-review.md
+```
 
 ## Step 2 — Merge
 

--- a/modes/review-round2.md
+++ b/modes/review-round2.md
@@ -2,6 +2,8 @@
 
 You are verifying that round-1 review issues have been fixed on PR #{{PR_NUMBER}} in `{{REPO}}`.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Find the original issues
 
 Use `gh pr view {{PR_NUMBER}} --repo {{REPO}} --comments` or GitHub MCP tools to read the PR comment timeline. Find the `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` comment and note every issue it listed.

--- a/modes/review.md
+++ b/modes/review.md
@@ -2,6 +2,8 @@
 
 You are reviewing PR #{{PR_NUMBER}} in the `{{REPO}}` repository.
 
+⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
+
 ## Step 1 — Review
 
 Delegate the review to a sub-agent. Do not review the code yourself.


### PR DESCRIPTION
This feature fixes a class of silent stdin-hang bugs that occurred whenever Ralph used `gh pr comment` (or similar `gh` subcommands) inside mode scripts without redirecting stdin from `/dev/null`. Because `gh` can block waiting for terminal input when no TTY is available in CI or non-interactive shells, every affected mode file now appends `< /dev/null` to all such calls. An explicit CI-failure handling template has also been added to `merge.md` so that future contributors have a clear pattern to follow.

Closes #15

## Tasks completed

- #16 fix: add gh stdin ground rule to all mode files and explicit CI-failure template to merge.md

## Known limitations / rough edges

- Only mode files that were identified during the PRD investigation have been updated; any future mode files added to the repo should follow the same `< /dev/null` pattern (now documented in `merge.md`).