### PR TITLE
feat: add upstream config for fork-based workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ Each iteration Ralph:
    echo 'ralph.toml' >> .gitignore
    ```
 
+### Fork-based workflow (work projects)
+
+If you work on a project you don't own (e.g. you can't merge your own PRs), use a fork:
+
+1. Fork the upstream repo on GitHub and clone your fork locally.
+2. Point `repo` at your fork and set `upstream` to the original:
+   ```toml
+   repo     = "you/project"          # your fork — Ralph owns this
+   upstream = "org/project"          # upstream — final PR lands here
+   test     = "npm test"
+   ```
+
+Ralph will keep all issues, branches, and intermediate PRs on your fork. When all task issues are closed, it opens a single `you:feat/<label> → org/project:main` PR for the upstream maintainers to review and merge.
+
 3. **Run from your project root:**
    ```bash
    ralph 20

--- a/modes/feature-pr.md
+++ b/modes/feature-pr.md
@@ -1,15 +1,15 @@
 # Ralph — Feature PR Mode
 
-All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been merged into `{{FEATURE_BRANCH}}`. Your job is to open a pull request from `{{FEATURE_BRANCH}}` to `main` for human review.
+All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been merged into `{{FEATURE_BRANCH}}`. Your job is to open a pull request from `{{FORK_OWNER}}:{{FEATURE_BRANCH}}` to `{{UPSTREAM_REPO}}` (main) for human review.
 
 ⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
 
 ## Step 1 — Verify no existing PR
 
-Check whether a `{{FEATURE_BRANCH}} → main` PR already exists:
+Check whether a `{{FEATURE_BRANCH}} → main` PR already exists on the upstream:
 
 ```bash
-gh pr list --repo {{REPO}} --state open --base main --head {{FEATURE_BRANCH}} --json number --jq '.[].number' < /dev/null
+gh pr list --repo {{UPSTREAM_REPO}} --state open --base main --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} --json number --jq '.[].number' < /dev/null
 ```
 
 If one already exists, emit `<promise>STOP</promise>` immediately and do nothing else.
@@ -33,17 +33,17 @@ gh issue list --repo {{REPO}} --state closed --label "{{FEATURE_LABEL}}" --json 
 
 Compose a PR description that:
 - Opens with a one-paragraph summary of what the feature does
-- References the parent PRD issue with `Closes #<prd-issue-number>`
-- Lists every task issue closed as part of this feature (e.g. `- #12 Short title`)
+- References the parent PRD issue with `Closes {{REPO}}#<prd-issue-number>` (cross-repo close syntax, since the issue lives on the fork)
+- Lists every task issue closed as part of this feature (e.g. `- {{REPO}}#12 Short title`)
 - Notes any known limitations or rough edges
 
 Then open the PR:
 
 ```bash
 gh pr create \
-  --repo {{REPO}} \
+  --repo {{UPSTREAM_REPO}} \
   --base main \
-  --head {{FEATURE_BRANCH}} \
+  --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} \
   --title "feat(<label>): <short summary>" \
   --body "<PR description>" \
   < /dev/null

--- a/project.example.toml
+++ b/project.example.toml
@@ -2,7 +2,15 @@
 # Copy this file to ralph.toml at your project root and fill in the values.
 
 # GitHub repo slug (owner/repo). Optional — Ralph infers it from `gh repo view`.
+# For fork-based workflows, set this to your fork (e.g. "you/project").
 repo = ""
+
+# Upstream repo slug (owner/repo). Only needed for fork-based workflows where
+# you want Ralph to open the final feature PR against an upstream repo you don't
+# own (e.g. "org/project"). When set, Ralph keeps all issues and intermediate
+# PRs on your fork, then opens the final feat→main PR against this upstream.
+# Leave empty for personal projects (Ralph defaults to `repo`).
+upstream = ""
 
 # Build command — leave empty if no build step.
 build = ""

--- a/ralph.sh
+++ b/ralph.sh
@@ -53,11 +53,20 @@ toml_get() {
 BUILD_CMD=$(toml_get build)
 TEST_CMD=$(toml_get test)
 REPO=$(toml_get repo)
+UPSTREAM_REPO=$(toml_get upstream)
 
 # Fall back to inferring the repo from the GitHub CLI.
 if [[ -z "$REPO" ]]; then
   REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
 fi
+
+# Upstream defaults to REPO for personal projects (same-repo workflow).
+if [[ -z "$UPSTREAM_REPO" ]]; then
+  UPSTREAM_REPO="$REPO"
+fi
+
+# Fork owner is the user/org prefix of REPO (e.g. "you" from "you/project").
+FORK_OWNER="${REPO%%/*}"
 
 # ── Argument validation ────────────────────────────────────────────────────────
 
@@ -311,6 +320,8 @@ build_prompt() {
   PROMPT="${PROMPT//\{\{TEST_CMD\}\}/$TEST_CMD}"
   PROMPT="${PROMPT//\{\{FEATURE_BRANCH\}\}/$FEATURE_BRANCH}"
   PROMPT="${PROMPT//\{\{FEATURE_LABEL\}\}/$FEATURE_LABEL}"
+  PROMPT="${PROMPT//\{\{UPSTREAM_REPO\}\}/$UPSTREAM_REPO}"
+  PROMPT="${PROMPT//\{\{FORK_OWNER\}\}/$FORK_OWNER}"
 }
 
 # ── Main loop ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Ralph currently assumes it owns the target repo — it creates issues, branches, PRs, and merges them all in `REPO`. This breaks for work projects where you don't own the upstream (can't merge your own PRs, don't want to pollute upstream with Ralph's issues).

## Solution

Add an `upstream` config key to `ralph.toml`. When set, Ralph:

- Keeps **all issues, branches, and intermediate PRs on the fork** (`repo`) where you're the owner and can merge freely
- Opens the **final `feat → main` PR against the upstream** repo using cross-repo syntax (`FORK_OWNER:FEATURE_BRANCH → UPSTREAM_REPO:main`)

When `upstream` is omitted, `UPSTREAM_REPO` defaults to `REPO` and the existing single-repo workflow is entirely unaffected.

## Changes

- **`project.example.toml`** — adds `upstream = ""` with explanatory comment
- **`ralph.sh`** — parses `upstream` from config; derives `FORK_OWNER` from `REPO`; exposes two new placeholders: `{{UPSTREAM_REPO}}` and `{{FORK_OWNER}}`
- **`modes/feature-pr.md`** — uses `{{UPSTREAM_REPO}}` and `{{FORK_OWNER}}:{{FEATURE_BRANCH}}` for the final PR; uses cross-repo issue-close syntax in the PR description
- **`README.md`** — adds a "Fork-based workflow" section to Setup

## Usage

```toml
# ralph.toml in your fork
repo     = "you/project"    # your fork — Ralph owns this
upstream = "org/project"    # upstream — final PR lands here
test     = "npm test"
```
