### PR TITLE
feat: blocked-by dependency enforcement in routing and merge (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `blocked_by` dependency enforcement in `determine_mode()`: tasks whose `blocked_by` dependency is not `done` are skipped; when all pending tasks are blocked, Ralph exits with a clear "blocked" message (exit 1) rather than falsely declaring complete (#25)
+- `modes/merge.md`: after marking a task `done`, queries for tasks blocked by it and emits a `🔓 Task N is now unblocked.` log line for each (#25)
 - `fix_count INTEGER DEFAULT 0` column on `tasks` table; existing DBs migrated via `ALTER TABLE` on startup (#24)
 - `force-approve` routing: when `status='needs_fix'` and `fix_count >= 2`, `determine_mode()` routes to `force-approve` instead of `fix` (#24)
 

--- a/modes/merge.md
+++ b/modes/merge.md
@@ -47,13 +47,25 @@ git branch -d "$TASK_BRANCH"
 sqlite3 {{DB_PATH}} "UPDATE tasks SET status='done' WHERE id={{TASK_ID}};"
 ```
 
-## Step 5 — Push feature branch
+## Step 5 — Log newly unblocked tasks
+
+After marking the task done, check for tasks that were blocked by it and are now unblocked:
+
+```bash
+UNBLOCKED=$(sqlite3 {{DB_PATH}} \
+  "SELECT id FROM tasks WHERE blocked_by={{TASK_ID}} AND status='pending';")
+for UNBLOCKED_ID in $UNBLOCKED; do
+  echo "  🔓 Task $UNBLOCKED_ID is now unblocked."
+done
+```
+
+## Step 6 — Push feature branch
 
 ```bash
 git push origin {{FEATURE_BRANCH}}
 ```
 
-## Step 6 — Stop
+## Step 7 — Stop
 
 Emit this token as your **final output** and end your response immediately:
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -308,7 +308,21 @@ determine_mode() {
     return
   fi
 
-  # 7. all tasks done → feature-pr or complete
+  # 7. pending tasks exist but all are blocked → wait
+  local blocked_pending_count
+  blocked_pending_count=$(sqlite3 "$DB_PATH" \
+    "SELECT COUNT(*) FROM tasks
+     WHERE status='pending'
+       AND blocked_by IS NOT NULL
+       AND blocked_by NOT IN (SELECT id FROM tasks WHERE status='done');" 2>/dev/null || echo "0")
+  if [[ "$blocked_pending_count" -gt 0 ]]; then
+    MODE="complete"
+    COMPLETE_REASON="blocked"
+    echo "  ⏸  All remaining tasks are blocked — waiting for dependencies to complete."
+    return
+  fi
+
+  # 8. all tasks done → feature-pr or complete
   local total_tasks done_tasks
   total_tasks=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM tasks;" 2>/dev/null || echo "0")
   done_tasks=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM tasks WHERE status='done';" 2>/dev/null || echo "0")
@@ -335,7 +349,7 @@ determine_mode() {
     return
   fi
 
-  # 8. Default fallback
+  # 9. Default fallback
   MODE="complete"
   echo "  ▶  Mode: $MODE  (no actionable tasks)"
 }
@@ -435,11 +449,20 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
   printf "\033k🤖 Ralph %s/%s\033\\" "$i" "$MAX_ITERATIONS"
 
   MODE=""
+  COMPLETE_REASON=""
   determine_mode
 
   # All done — no copilot needed
   if [[ "$MODE" == "complete" ]]; then
     echo ""
+    if [[ "$COMPLETE_REASON" == "blocked" ]]; then
+      printf "\033[1;33m"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo "  ⏸  Ralph stopped — blocked tasks remain, no actionable work at iteration $i / $MAX_ITERATIONS"
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      printf "\033[0m"
+      exit 1
+    fi
     printf "\033[1;32m"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "  ✅  Ralph completed all tasks at iteration $i / $MAX_ITERATIONS"


### PR DESCRIPTION
Closes #25

## What was implemented

### Routing (`ralph.sh` — `determine_mode()`)

Added step 7 between the "unblocked pending → implement" check and the "all done → feature-pr/complete" check:

- Counts pending tasks whose `blocked_by` blocker is **not** yet `done`
- If any exist (all pending tasks are blocked with no actionable work), sets `COMPLETE_REASON=blocked` and exits with a clear yellow warning message + **exit 1**, rather than falsely printing "✅ Ralph completed all tasks"

The main loop now distinguishes two `complete` exit paths:
- `COMPLETE_REASON=blocked` → yellow banner, `exit 1`
- Normal completion → green banner, `exit 0`

### Merge mode (`modes/merge.md`)

After step 4 (marking task `done`), a new **step 5** queries for tasks that were `blocked_by` the just-completed task and emits a `🔓 Task N is now unblocked.` log line for each. The routing query in the next iteration automatically picks them up.

## Limitations / known rough edges

- `blocked_by` is a single INTEGER foreign key — only one blocker per task is supported. Chains work correctly (A→B→C), but diamond dependencies require a separate join table (out of scope for this issue).
- The "blocked" exit uses `exit 1` to distinguish it from true completion. Callers watching the exit code will see a non-zero exit even though Ralph stopped intentionally.
