### PR TITLE
feat: blocked-by dependency enforcement (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `blocked_by` dependency enforcement in `determine_mode()`: pending tasks whose `blocked_by` list contains any task ID not yet `status: done` are skipped; if all remaining pending tasks are blocked, routing exits with a `🚫 blocked` message and exit code 1 rather than looping (#40)
+- Step 5 in `merge.md`: after marking a task `done`, scans all other task files for any pending tasks that listed the completed task in their `blocked_by` field and logs which tasks are now unblocked (#40)
+
+### Added
 - `review.md` (markdown-backend): reads branch from task file front matter, diffs local task branch against feature branch via sub-agent, writes `review_notes` as a YAML block scalar and sets `status: needs_fix` on issues, or performs local merge and sets `status: done` on approval — no GitHub PR comments (#39)
 - `review-round2.md` (markdown-backend): same as `review.md` but also reads prior `review_notes` from front matter as context for the verification sub-agent (#39)
 - `fix.md` (markdown-backend): reads `review_notes` and `branch` from task file front matter, checks out the task branch, applies fixes, increments `fix_count`, and sets `status: needs_review_2` (#39)

--- a/modes/merge.md
+++ b/modes/merge.md
@@ -61,7 +61,44 @@ git add "{{TASK_FILE}}"
 git commit -m "chore: mark task {{TASK_ID}} done"
 ```
 
-## Step 5 — Stop
+## Step 5 — Log newly unblocked tasks
+
+Scan all other task files in `{{PLANS_DIR}}` for any that list `{{TASK_ID}}` in their `blocked_by` field. Print the names of any tasks that are now unblocked. No changes are needed — routing will pick them up automatically on the next iteration.
+
+```bash
+python3 - <<'EOF'
+import re, glob, os
+
+task_id = int("{{TASK_ID}}")
+plans_dir = "{{PLANS_DIR}}"
+task_file = "{{TASK_FILE}}"
+
+unblocked = []
+for path in sorted(glob.glob(os.path.join(plans_dir, '*.md'))):
+    if os.path.abspath(path) == os.path.abspath(task_file):
+        continue
+    content = open(path).read()
+    m = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not m:
+        continue
+    blocked_by_line = re.search(r'^blocked_by\s*:\s*(.+)$', m.group(1), re.MULTILINE)
+    if not blocked_by_line:
+        continue
+    ids = [int(x) for x in re.findall(r'\d+', blocked_by_line.group(1))]
+    if task_id in ids:
+        status_match = re.search(r'^status\s*:\s*(\S+)', m.group(1), re.MULTILINE)
+        status = status_match.group(1).strip('"\'') if status_match else 'unknown'
+        if status == 'pending':
+            unblocked.append(os.path.basename(path))
+
+if unblocked:
+    print(f"Tasks now unblocked by completing task {{TASK_ID}}: {', '.join(unblocked)}")
+else:
+    print("No pending tasks were waiting on task {{TASK_ID}}.")
+EOF
+```
+
+## Step 6 — Stop
 
 Emit this token as your **final output** and end your response immediately:
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -347,7 +347,7 @@ if all(t['status'] == 'done' for t in tasks):
     sys.exit(0)
 
 # Otherwise (all remaining tasks are blocked)
-print('complete\t\t')
+print('blocked\t\t')
 PYEOF
 ); then
     echo "Error: routing script failed — check task files in ${PLANS_DIR}"
@@ -371,6 +371,9 @@ PYEOF
       MODE="complete"
       echo "  ▶  Mode: $MODE  (all tasks done, feature PR already open)"
     fi
+  elif [[ "$mode" == "blocked" ]]; then
+    MODE="blocked"
+    echo "  ▶  Mode: blocked  (all remaining pending tasks are blocked)"
   else
     MODE="$mode"
     TASK_FILE="$task_file"
@@ -451,6 +454,17 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     printf "\033[0m"
     exit 0
+  fi
+
+  # Blocked — all remaining pending tasks are waiting on unfinished dependencies
+  if [[ "$MODE" == "blocked" ]]; then
+    echo ""
+    printf "\033[1;33m"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  🚫  Ralph stopped: all remaining tasks are blocked by unfinished dependencies"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    printf "\033[0m"
+    exit 1
   fi
 
   build_prompt


### PR DESCRIPTION
Closes #40

## What was implemented

### Routing (`ralph.sh`)
- The Python routing script in `determine_mode()` now returns `blocked` (instead of `complete`) when there are remaining pending tasks but all of them have unfinished dependencies in their `blocked_by` field.
- The bash routing handler recognises `blocked` as a distinct mode and sets `MODE="blocked"`.
- The main loop exits immediately with a `🚫 blocked` message and exit code 1 when `MODE == "blocked"`, rather than running Copilot or looping.

### `merge.md`
- New Step 5: after marking a task `status: done`, scans all other task files in `{{PLANS_DIR}}` for any pending tasks whose `blocked_by` list includes the just-completed task ID, and logs which tasks are now unblocked. No mutation is performed — routing naturally picks them up on the next iteration.

### Backward compatibility
- Tasks with `blocked_by: []` are treated as unblocked (pass `deps_done`).
- Tasks without a `blocked_by` key default to an empty list and are treated as unblocked.

## Limitations / known rough edges
- The `blocked_by` scan in `merge.md` is purely informational (logging). No automatic status updates or re-ordering occurs — that's by design per the issue spec.
