### PR TITLE
feat: introduce approved status as intermediate review→merge step (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- `review.md`: LGTM path now sets `status: approved` and commits instead of immediately merging; merge is deferred to `merge` mode (#51)
+- `review-round2.md`: LGTM path now sets `status: approved` and commits instead of immediately merging; merge is deferred to `merge` mode (#51)
+- `lib/functions.sh`: renumbered routing priorities 2→3 (needs_review_2), 3→4 (needs_fix), 4→5 (in_progress), 5→6 (pending) to make room for new priority 2 (approved) (#51)
 - `review_notes` in task file front matter changed from a single overwritten block scalar to an append-only list of `|` block scalars; each review round appends a new entry preserving full history (#50)
 - `review.md`: Step 6 now appends a new `|` block scalar entry to the `review_notes` list instead of overwriting it (#50)
 - `review-round2.md`: Step 1 now reads and displays all `review_notes` entries for context; Step 6 appends a new entry instead of overwriting (#50)
@@ -17,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - `lib/functions.sh`: `append_review_note`, `get_last_review_note`, and `get_all_review_notes` helper functions for review notes array manipulation (#50)
 - `test/yaml_helpers.bats`: tests for `append_review_note` (empty list, two rounds, colons, multi-line, field preservation, body preservation), `get_last_review_note`, and `get_all_review_notes` (#50)
+- `status: approved` as a distinct intermediate state between review and merge; `determine_mode()` routes `approved → merge` at priority 2 (#51)
+- `test/routing.bats`: tests for `approved → merge` routing and priority ordering of `approved` vs `needs_review` and `needs_review_2` (#51)
 
 
 - `test/routing.bats`: bats test suite covering all `determine_mode()` routing cases — pending→implement, in_progress→fix, needs_review→review, needs_fix (fix_count=0)→fix, needs_fix (fix_count≥2)→force-approve, needs_review_2→review-round2/force-approve, all-done→feature-pr/complete, all-blocked→blocked, priority ordering, and blocked-by dependency skipping (#42)

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -235,7 +235,13 @@ for t in tasks:
         print(f"review\t{t['file']}\t{t['id']}")
         sys.exit(0)
 
-# Priority 2: needs_review_2 — force-approve if fix_count >= 2, else review-round2
+# Priority 2: approved — route to merge
+for t in tasks:
+    if t['status'] == 'approved':
+        print(f"merge\t{t['file']}\t{t['id']}")
+        sys.exit(0)
+
+# Priority 3: needs_review_2 — force-approve if fix_count >= 2, else review-round2
 for t in tasks:
     if t['status'] == 'needs_review_2':
         if t['fix_count'] >= 2:
@@ -244,7 +250,7 @@ for t in tasks:
             print(f"review-round2\t{t['file']}\t{t['id']}")
         sys.exit(0)
 
-# Priority 3: needs_fix — force-approve if fix_count >= 2, else fix
+# Priority 4: needs_fix — force-approve if fix_count >= 2, else fix
 for t in tasks:
     if t['status'] == 'needs_fix':
         if t['fix_count'] >= 2:
@@ -253,13 +259,13 @@ for t in tasks:
             print(f"fix\t{t['file']}\t{t['id']}")
         sys.exit(0)
 
-# Priority 4: in_progress (resume interrupted work)
+# Priority 5: in_progress (resume interrupted work)
 for t in tasks:
     if t['status'] == 'in_progress':
         print(f"fix\t{t['file']}\t{t['id']}")
         sys.exit(0)
 
-# Priority 5: pending with all blocked_by deps done (high priority first)
+# Priority 6: pending with all blocked_by deps done (high priority first)
 ready = [t for t in tasks if t['status'] == 'pending' and deps_done(t['blocked_by'])]
 high = [t for t in ready if t['priority'] == 'high']
 if high:

--- a/modes/review-round2.md
+++ b/modes/review-round2.md
@@ -59,30 +59,15 @@ Launch a **general-purpose sub-agent** with this prompt, substituting the real b
 > For each original issue, state: RESOLVED or UNRESOLVED (with a brief reason).
 > If all are RESOLVED, return exactly the word: LGTM"
 
-**If LGTM (all resolved):** proceed to steps 3–5 to merge and mark done.
+**If LGTM (all resolved):** proceed to steps 3–5 to set `status: approved`.
 
 **If any issues are UNRESOLVED:** proceed to step 6 to update review notes and set `status: needs_fix`.
 
 ---
 
-## Steps 3–5: Merge and mark done (LGTM path)
+## Steps 3–5: Approve (LGTM path)
 
-### Step 3 — Merge into feature branch
-
-```bash
-git checkout {{FEATURE_BRANCH}}
-git merge --no-ff <branch>
-```
-
-If the merge exits non-zero (conflicts), run `git merge --abort`, then emit `<promise>STOP</promise>` as your final output and stop immediately.
-
-### Step 4 — Delete the task branch
-
-```bash
-git branch -d <branch>
-```
-
-### Step 5 — Set `status: done` and commit
+### Step 3 — Set `status: approved` and commit
 
 ```bash
 python3 - <<'EOF'
@@ -90,12 +75,12 @@ import re
 path = "{{TASK_FILE}}"
 with open(path) as f:
     content = f.read()
-content = re.sub(r'(?m)^(status:\s*)\S+', r'\g<1>done', content, count=1)
+content = re.sub(r'(?m)^(status:\s*)\S+', r'\g<1>approved', content, count=1)
 with open(path, 'w') as f:
     f.write(content)
 EOF
 git add "{{TASK_FILE}}"
-git commit -m "chore: mark task {{TASK_ID}} done after round-2 review approval"
+git commit -m "chore: task {{TASK_ID}} approved after round-2 review — ready to merge"
 ```
 
 Then emit `<promise>STOP</promise>` as your **final output** and stop immediately.

--- a/modes/review.md
+++ b/modes/review.md
@@ -35,30 +35,15 @@ Launch a **general-purpose sub-agent** with this prompt, substituting the real b
 > For each issue found, return: file path, approximate line number, a clear description of the problem, and a concrete suggested fix.
 > If you find no genuine issues, return exactly the word: LGTM"
 
-**If LGTM:** proceed to steps 3–5 to merge and mark done.
+**If LGTM:** proceed to steps 3–5 to set `status: approved`.
 
 **If issues found:** proceed to step 6 to save review notes and set `status: needs_fix`.
 
 ---
 
-## Steps 3–5: Merge and mark done (LGTM path)
+## Steps 3–5: Approve (LGTM path)
 
-### Step 3 — Merge into feature branch
-
-```bash
-git checkout {{FEATURE_BRANCH}}
-git merge --no-ff <branch>
-```
-
-If the merge exits non-zero (conflicts), run `git merge --abort`, then emit `<promise>STOP</promise>` as your final output and stop immediately.
-
-### Step 4 — Delete the task branch
-
-```bash
-git branch -d <branch>
-```
-
-### Step 5 — Set `status: done` and commit
+### Step 3 — Set `status: approved` and commit
 
 ```bash
 python3 - <<'EOF'
@@ -66,12 +51,12 @@ import re
 path = "{{TASK_FILE}}"
 with open(path) as f:
     content = f.read()
-content = re.sub(r'(?m)^(status:\s*)\S+', r'\g<1>done', content, count=1)
+content = re.sub(r'(?m)^(status:\s*)\S+', r'\g<1>approved', content, count=1)
 with open(path, 'w') as f:
     f.write(content)
 EOF
 git add "{{TASK_FILE}}"
-git commit -m "chore: mark task {{TASK_ID}} done after review approval"
+git commit -m "chore: task {{TASK_ID}} approved — ready to merge"
 ```
 
 Then emit `<promise>STOP</promise>` as your **final output** and stop immediately.

--- a/test/routing.bats
+++ b/test/routing.bats
@@ -87,6 +87,29 @@ teardown() {
   [ "$TASK_ID" = "01" ]
 }
 
+@test "approved task → merge" {
+  create_task_file "$PLANS_DIR" "01-task.md" "status=approved"
+  determine_mode
+  [ "$MODE"    = "merge" ]
+  [ "$TASK_ID" = "01" ]
+}
+
+@test "approved task takes priority over needs_review_2" {
+  create_task_file "$PLANS_DIR" "01-task.md" "status=approved"
+  create_task_file "$PLANS_DIR" "02-task.md" "status=needs_review_2"
+  determine_mode
+  [ "$MODE"    = "merge" ]
+  [ "$TASK_ID" = "01" ]
+}
+
+@test "needs_review takes priority over approved" {
+  create_task_file "$PLANS_DIR" "01-task.md" "status=needs_review"
+  create_task_file "$PLANS_DIR" "02-task.md" "status=approved"
+  determine_mode
+  [ "$MODE"    = "review" ]
+  [ "$TASK_ID" = "01" ]
+}
+
 # ── Routing: all-done cases ───────────────────────────────────────────────────
 
 @test "all tasks done, no feature label → complete" {


### PR DESCRIPTION
Closes #51

## What was implemented

Introduces `status: approved` as a distinct intermediate state between review and merge, making the review→merge transition crash-safe.

### Changes

- **`review.md`** and **`review-round2.md`**: The LGTM path no longer immediately merges the task branch. Instead, it sets `status: approved` on the task file and commits. The merge is deferred to the next Ralph iteration, which will route to `merge` mode.

- **`lib/functions.sh`**: Added a priority-2 routing check — if any task has `status: approved`, `determine_mode()` routes to `merge` mode. Existing priorities renumbered (needs_review_2→3, needs_fix→4, in_progress→5, pending→6).

- **`merge.md`**: No changes needed — already performs the local merge and sets `status: done`.

- **`test/routing.bats`**: Added three new tests:
  - `approved task → merge`
  - `approved task takes priority over needs_review_2`
  - `needs_review takes priority over approved`

### Crash-safety

If Ralph is killed after approval but before merge, restarting will correctly detect `status: approved` at priority 2 and resume at `merge` mode.

## Test results

All 42 bats tests pass (21 routing + 21 yaml_helpers).

## Limitations / known rough edges

None.
