### PR TITLE
test: bats coverage for block scalar review_notes in get_front_matter_field (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - `lib/functions.sh`: `append_review_note`, `get_last_review_note`, and `get_all_review_notes` helper functions for review notes array manipulation (#50)
 - `test/yaml_helpers.bats`: tests for `append_review_note` (empty list, two rounds, colons, multi-line, field preservation, body preservation), `get_last_review_note`, and `get_all_review_notes` (#50)
+- `test/yaml_helpers.bats`: bats tests for `get_front_matter_field` with `|` block scalar `review_notes` — empty-string return, no corruption of sibling fields, colons in block scalar content, multiline block scalar content, and two-round append preserving all front matter fields (#52)
 - `status: approved` as a distinct intermediate state between review and merge; `determine_mode()` routes `approved → merge` at priority 2 (#51)
 - `test/routing.bats`: tests for `approved → merge` routing and priority ordering of `approved` vs `needs_review` and `needs_review_2` (#51)
 

--- a/test/yaml_helpers.bats
+++ b/test/yaml_helpers.bats
@@ -184,3 +184,62 @@ EOF
   count=$(grep -c '  - |' "$TEST_FILE")
   [ "$count" -eq 2 ]
 }
+
+# ── get_front_matter_field: block scalar review_notes ────────────────────────
+
+setup_block_scalar_notes_file() {
+  cat > "$TEST_FILE" <<'EOF'
+---
+status: needs_review
+priority: high
+fix_count: 1
+branch: ralph/task-07
+review_notes:
+  - |
+    Looks good overall
+---
+
+# Task body
+
+Some content here.
+EOF
+}
+
+@test "get_front_matter_field returns empty string for block scalar review_notes list" {
+  setup_block_scalar_notes_file
+  result="$(get_front_matter_field "$TEST_FILE" "review_notes")"
+  [ "$result" = "" ]
+}
+
+@test "get_front_matter_field reads other fields correctly when review_notes is a block scalar" {
+  setup_block_scalar_notes_file
+  [ "$(get_front_matter_field "$TEST_FILE" "status")"    = "needs_review" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "priority")"  = "high" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "fix_count")" = "1" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "branch")"    = "ralph/task-07" ]
+}
+
+@test "get_front_matter_field reads other fields when review_notes block scalar contains colons" {
+  setup_review_notes_file
+  append_review_note "$TEST_FILE" "src/auth.ts line 42: missing null check — returns 403 instead of 401"
+  [ "$(get_front_matter_field "$TEST_FILE" "status")"    = "needs_review" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "branch")"    = "ralph/task-07" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "fix_count")" = "0" ]
+}
+
+@test "get_front_matter_field reads other fields when review_notes is a multiline block scalar" {
+  setup_review_notes_file
+  append_review_note "$TEST_FILE" "$(printf 'Line one: first issue\nLine two: second issue\nLine three: third issue')"
+  [ "$(get_front_matter_field "$TEST_FILE" "status")"    = "needs_review" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "branch")"    = "ralph/task-07" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "fix_count")" = "0" ]
+}
+
+@test "appending block scalar entries with colons does not corrupt other front matter fields" {
+  setup_review_notes_file
+  append_review_note "$TEST_FILE" "src/auth.ts line 42: token expiry missing"
+  append_review_note "$TEST_FILE" "api/routes.ts line 15: missing error handler"
+  [ "$(get_front_matter_field "$TEST_FILE" "status")"    = "needs_review" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "branch")"    = "ralph/task-07" ]
+  [ "$(get_front_matter_field "$TEST_FILE" "fix_count")" = "0" ]
+}


### PR DESCRIPTION
Closes #52

## What was implemented

Added 5 new bats tests in `test/yaml_helpers.bats` covering `get_front_matter_field` behaviour when `review_notes` is stored as a YAML `|` block scalar list (as written by `append_review_note`):

1. **Empty-string return** — `get_front_matter_field` returns `""` for a block-scalar list `review_notes` (no inline value on the `review_notes:` line).
2. **Sibling field integrity** — all other front matter fields (`status`, `priority`, `fix_count`, `branch`) are still read correctly when `review_notes` is a block scalar.
3. **Colons in block scalar content** — sibling fields are unaffected when the block scalar entry contains colons (e.g. `src/auth.ts line 42: missing null check`).
4. **Multiline block scalar** — sibling fields are unaffected when the block scalar spans multiple lines.
5. **Two-round append with colons** — after two `append_review_note` calls whose text includes colons, all sibling front matter fields remain correct.

A `setup_block_scalar_notes_file` helper was added to pre-build a test fixture with a hand-written block scalar list, so tests don't depend on `append_review_note` to reach this state.

## Notes / limitations

- `get_front_matter_field("review_notes")` intentionally returns `""` when `review_notes` is a block scalar list; callers that need the note text should use `get_last_review_note` / `get_all_review_notes`.
- No implementation changes were made — this PR is test-only as specified by the issue.
