### PR TITLE
feat(markdown-backend): squash merge feature PR into main (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Preflight existence check for `plans/<label>/` still validates against `$GIT_ROOT` (before the worktree is created) via a separate `PLANS_DIR_SRC` variable (#53)
 
 ### Changed
+- `feature-pr.md`: squash-merges the `feat/ → main` PR with `--squash --delete-branch` so `main` receives a single commit per feature instead of the full task-by-task history (#56)
 - `review.md`: LGTM path now sets `status: approved` and commits instead of immediately merging; merge is deferred to `merge` mode (#51)
 - `review-round2.md`: LGTM path now sets `status: approved` and commits instead of immediately merging; merge is deferred to `merge` mode (#51)
 - `lib/functions.sh`: renumbered routing priorities 2→3 (needs_review_2), 3→4 (needs_fix), 4→5 (in_progress), 5→6 (pending) to make room for new priority 2 (approved) (#51)

--- a/modes/feature-pr.md
+++ b/modes/feature-pr.md
@@ -1,6 +1,6 @@
 # Ralph — Feature PR Mode
 
-All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been merged into `{{FEATURE_BRANCH}}`. Your job is to open a pull request from `{{FEATURE_BRANCH}}` to `main` for human review.
+All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been merged into `{{FEATURE_BRANCH}}`. Your job is to open a pull request from `{{FEATURE_BRANCH}}` to `main` and squash-merge it so the feature lands on `main` as a single commit.
 
 ⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
 
@@ -51,11 +51,17 @@ gh pr create \
 
 Replace `<label>` with the short label name (e.g. `foo-widget` from `feat/foo-widget`).
 
-## ⚠️ Critical constraint
+## Step 4 — Squash merge the pull request
 
-**You must never review, approve, or merge this PR.** Your role ends the moment the PR is opened. This PR is for human review only. Do not request a review, do not approve it, and do not merge it under any circumstances.
+Once the PR is open, immediately merge it using squash merge and delete the feature branch:
 
-## Step 4 — Stop
+```bash
+gh pr merge --repo {{REPO}} --squash --delete-branch < /dev/null
+```
+
+This ensures `main` receives a single squashed commit representing the entire feature, rather than exposing all of Ralph's intermediate working commits (implement, fix, re-review, merge task, etc.).
+
+## Step 5 — Stop
 
 Emit this token as your **final output** and stop:
 


### PR DESCRIPTION
Closes #56

## What was implemented

Updated `modes/feature-pr.md` to squash-merge the `feat/ → main` PR immediately after opening it, rather than leaving it for manual human merge.

**Changes:**
- Removed the "Critical constraint" block that previously prohibited Ralph from merging the feature PR
- Added Step 4: squash-merges the newly-opened PR using `gh pr merge --repo {{REPO}} --squash --delete-branch < /dev/null`
- Updated the opening paragraph to reflect that Ralph's role now includes merging
- The feature branch is deleted after the squash merge

**Why squash merge?** Each task PR was already reviewed individually before being merged into the feature branch. The feature→main PR exposes all of Ralph's intermediate working commits (implement, fix, re-review, merge task, etc.). Squash-merging collapses these into a single clean commit on `main`.

## Limitations / known rough edges

- Ralph opens and immediately squash-merges the PR with no pause for human review at the feature-PR level. This is intentional — review happens at the task level.
- If the repo's branch protection requires approvals before merge, `gh pr merge --squash` will fail. In that case the operator would need to approve the PR manually before Ralph can merge it (or disable the branch protection requirement for the feature → main merge).
