### PR TITLE
feat: squash merge per-task PRs into feature branch with branch deletion (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- `merge.md` now uses `gh pr merge --squash --delete-branch` so per-task PRs are squash-merged into the feature branch and the `ralph/issue-N` remote branch is deleted after merge (#79)
+
 ### Added
 - `modes/escalate.md`: new mode that ensures the `needs-human-review` label exists, labels the PR `needs-human-review`, labels the originating issue `blocked`, posts an explanatory comment on the PR, and emits STOP so the outer loop skips to the next unblocked task (#78)
 - `detect_review_backend()` function in `ralph.sh` that queries the GitHub API at startup, sets `REVIEW_BACKEND` to `copilot` when `copilot-pull-request-reviewer` is installed on the repo, and defaults to `comments` on any API failure or when the app is absent (#76)

--- a/modes/merge.md
+++ b/modes/merge.md
@@ -38,7 +38,7 @@ rm /tmp/ralph-review.md
 ## Step 2 — Merge
 
 ```bash
-gh pr merge {{PR_NUMBER}} --repo {{REPO}} --merge < /dev/null
+gh pr merge {{PR_NUMBER}} --repo {{REPO}} --squash --delete-branch < /dev/null
 ```
 
 ## Step 3 — Update workspace to new `{{FEATURE_BRANCH}}`


### PR DESCRIPTION
Closes #79

## Summary

Updates `merge.md` to use `gh pr merge --squash --delete-branch` instead of `--merge`. This ensures:

- Per-task PRs are squash-merged into the feature branch, resulting in exactly one new commit per completed task
- The `ralph/issue-N` remote branch is deleted automatically after merge, keeping the remote clean

All other merge behaviour (merging into the feature branch, CI checks, closing the issue, rebasing downstream PRs) is unchanged.

## Limitations

None known.
