### PR TITLE
feat: upstream config for fork-based workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `upstream` config key in `project.example.toml` for fork-based workflows; when set, the final feature PR is opened against the upstream repo instead of the fork (#93)
+- `UPSTREAM_REPO` variable in `ralph.sh` (defaults to `$REPO` when `upstream` is unset, preserving existing behaviour) (#93)
+- `FORK_OWNER` variable derived from the owner prefix of `$REPO` (#93)
+- `{{UPSTREAM_REPO}}` and `{{FORK_OWNER}}` placeholder substitutions in `build_prompt()` (#93)
+- Fork-based workflow documentation in `README.md` (#93)
+
 ### Changed
+- `modes/feature-pr.md` now checks for an existing PR against `{{UPSTREAM_REPO}}` with head `{{FORK_OWNER}}:{{FEATURE_BRANCH}}`, opens the PR with `--repo {{UPSTREAM_REPO}} --head {{FORK_OWNER}}:{{FEATURE_BRANCH}}`, and uses cross-repo `Closes {{REPO}}#` syntax in the PR body (#93)
 - `merge.md` now uses `gh pr merge --squash --delete-branch` so per-task PRs are squash-merged into the feature branch and the `ralph/issue-N` remote branch is deleted after merge (#79)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Each iteration Ralph:
    # Optional — Ralph infers this from `gh repo view` if omitted
    repo = "your-org/your-repo"
 
+   # Optional — for fork-based workflows (see below)
+   upstream = ""
+
    # Leave empty if there is no build step
    build = "npm run build"
 
@@ -86,7 +89,23 @@ To override Ralph's prompts for a specific project, create a `ralph/modes/` dire
 
 Use `/write-a-prd` and `/prd-to-issues` Copilot skills to create PRDs and task issues with the correct labels applied automatically.
 
-## Stopping Ralph
+## Fork-based workflows
+
+If Ralph is doing all the work on your fork (`you/project`) but the final feature PR should land on the upstream repo (`org/project`), set `upstream` in `ralph.toml`:
+
+```toml
+repo     = "you/project"   # your fork — Ralph owns this
+upstream = "org/project"   # upstream — final PR lands here
+```
+
+When `upstream` is set:
+- All issues and intermediate PRs continue to use `repo` (your fork).
+- The final `feature-pr` mode opens the PR against `upstream` with the correct cross-fork head (`you:feat/<label>`).
+- Issue-close links in the PR body use the cross-repo syntax (`Closes you/project#<n>`) so they auto-close on merge.
+
+When `upstream` is **not** set, behaviour is identical to today.
+
+
 
 Ralph stops automatically when:
 - All open issues are closed and all ralph PRs are merged (emits `COMPLETE`)

--- a/modes/feature-pr.md
+++ b/modes/feature-pr.md
@@ -6,10 +6,10 @@ All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been 
 
 ## Step 1 — Verify no existing PR
 
-Check whether a `{{FEATURE_BRANCH}} → main` PR already exists:
+Check whether a `{{FEATURE_BRANCH}} → main` PR already exists against the upstream repo:
 
 ```bash
-gh pr list --repo {{REPO}} --state open --base main --head {{FEATURE_BRANCH}} --json number --jq '.[].number' < /dev/null
+gh pr list --repo {{UPSTREAM_REPO}} --state open --base main --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} --json number --jq '.[].number' < /dev/null
 ```
 
 If one already exists, emit `<promise>STOP</promise>` immediately and do nothing else.
@@ -33,23 +33,26 @@ gh issue list --repo {{REPO}} --state closed --label "{{FEATURE_LABEL}}" --json 
 
 Compose a PR description that:
 - Opens with a one-paragraph summary of what the feature does
-- References the parent PRD issue with `Closes #<prd-issue-number>`
-- Lists every task issue closed as part of this feature (e.g. `- #12 Short title`)
+- References the parent PRD issue with `Closes {{REPO}}#<prd-issue-number>` (cross-repo syntax)
+- Lists every task issue closed as part of this feature (e.g. `- {{REPO}}#12 Short title`)
 - Notes any known limitations or rough edges
 
 Then open the PR:
 
 ```bash
 gh pr create \
-  --repo {{REPO}} \
+  --repo {{UPSTREAM_REPO}} \
   --base main \
-  --head {{FEATURE_BRANCH}} \
+  --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} \
   --title "feat(<label>): <short summary>" \
   --body "<PR description>" \
   < /dev/null
 ```
 
 Replace `<label>` with the short label name (e.g. `foo-widget` from `feat/foo-widget`).
+
+When composing the PR description, use cross-repo issue-close syntax so the issue on the fork is closed when the upstream PR is merged:
+- `Closes {{REPO}}#<prd-issue-number>` (instead of bare `Closes #<number>`)
 
 ## ⚠️ Critical constraint
 

--- a/project.example.toml
+++ b/project.example.toml
@@ -4,6 +4,12 @@
 # GitHub repo slug (owner/repo). Optional — Ralph infers it from `gh repo view`.
 repo = ""
 
+# Upstream repo slug (owner/repo). Optional — for fork-based workflows where
+# Ralph does all his work on your fork but the final feature PR should land on
+# the upstream repo. Defaults to `repo` when not set (personal project behaviour
+# unchanged).
+upstream = ""
+
 # Build command — leave empty if no build step.
 build = ""
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -59,6 +59,15 @@ if [[ -z "$REPO" ]]; then
   REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
 fi
 
+UPSTREAM_REPO=$(toml_get upstream)
+# Default to $REPO when upstream is not configured (personal project behaviour unchanged).
+if [[ -z "$UPSTREAM_REPO" ]]; then
+  UPSTREAM_REPO="$REPO"
+fi
+
+# Derive the fork owner from the owner prefix of $REPO (e.g. "you" from "you/project").
+FORK_OWNER="${REPO%%/*}"
+
 # ── Argument validation ────────────────────────────────────────────────────────
 
 usage() {
@@ -203,6 +212,8 @@ build_prompt() {
   PROMPT="${PROMPT//\{\{FEATURE_BRANCH\}\}/$FEATURE_BRANCH}"
   PROMPT="${PROMPT//\{\{FEATURE_LABEL\}\}/$FEATURE_LABEL}"
   PROMPT="${PROMPT//\{\{REVIEW_BACKEND\}\}/$REVIEW_BACKEND}"
+  PROMPT="${PROMPT//\{\{UPSTREAM_REPO\}\}/$UPSTREAM_REPO}"
+  PROMPT="${PROMPT//\{\{FORK_OWNER\}\}/$FORK_OWNER}"
 }
 
 # ── Startup detection ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #93

## Summary

Adds an optional `upstream` config key to `ralph.toml` that allows Ralph to open the final `feat/ → main` PR against an upstream repo rather than the fork where all the work happened. This is essential for fork-based workflows where Ralph operates on `you/project` but the final PR should land on `org/project` for upstream maintainers to review and merge.

## Changes

- **`project.example.toml`**: Added `upstream = ""` field with explanatory comment
- **`ralph.sh`**:
  - Reads `upstream` from config via `toml_get`
  - Derives `UPSTREAM_REPO` (defaults to `$REPO` when `upstream` is unset — personal project behaviour unchanged)
  - Derives `FORK_OWNER` from the owner prefix of `$REPO`
  - Adds `{{UPSTREAM_REPO}}` and `{{FORK_OWNER}}` placeholder substitutions in `build_prompt()`
- **`modes/feature-pr.md`**:
  - Checks for existing PR against `{{UPSTREAM_REPO}}` with head `{{FORK_OWNER}}:{{FEATURE_BRANCH}}`
  - Opens PR with `--repo {{UPSTREAM_REPO}} --head {{FORK_OWNER}}:{{FEATURE_BRANCH}}`
  - Uses cross-repo `Closes {{REPO}}#<n>` syntax so issues auto-close on merge
- **`README.md`**: New "Fork-based workflows" section documenting the `upstream` key

## Known limitations / rough edges

- `FORK_OWNER` is derived purely from the `repo` string prefix (`${REPO%%/*}`). If `repo` is inferred by `gh repo view` from a non-fork context, `FORK_OWNER` will be the org/user of the inferred repo — which is usually correct, but worth being aware of.
- No validation that `upstream` is a different repo from `repo`; setting them to the same value is harmless (redundant cross-repo syntax but functionally identical).
