### PR TITLE
feat(single-issue): add --issue=N flag to target a specific issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `--issue=<N>` flag to `ralph.sh` to pin Ralph to a single specific issue, skipping normal label-based routing; when the issue's PR is merged and closed, Ralph exits cleanly without opening a feature PR (#96)
+- Pinned-issue routing in `determine_mode()` in `lib/routing.sh`: when `PINNED_ISSUE` is set, checks the issue state directly and routes to `implement` (open) or `complete` (closed) (#96)
+- Preflight check in `ralph.sh` that exits immediately with a clear message if the pinned issue is already closed (#96)
+- `gh issue view` support in `test/helpers/gh` mock binary via `MOCK_ISSUE_VIEW_RESPONSE` (#96)
+- Four bats test cases for `PINNED_ISSUE` routing scenarios in `test/routing.bats` (#96)
+
 - `upstream` config key in `project.example.toml` for fork-based workflows; when set, the final feature PR is opened against the upstream repo instead of the fork (#93)
 - `UPSTREAM_REPO` variable in `ralph.sh` (defaults to `$REPO` when `upstream` is unset, preserving existing behaviour) (#93)
 - `FORK_OWNER` variable derived from the owner prefix of `$REPO` (#93)

--- a/lib/routing.sh
+++ b/lib/routing.sh
@@ -125,10 +125,25 @@ determine_mode() {
   else
     echo "  🔍 No open ralph PRs — checking issues…"
 
+    if [[ -n "${PINNED_ISSUE:-}" ]]; then
+      # Single-issue mode: check if the pinned issue is still open.
+      PINNED_STATE=$(gh issue view "$PINNED_ISSUE" --repo "$REPO" --json state \
+        --jq '.state' < /dev/null 2>/dev/null || echo "")
+      if [[ -z "$PINNED_STATE" ]]; then
+        echo "  ⚠  Could not determine state of pinned issue #${PINNED_ISSUE} — skipping"
+        MODE="complete"
+      elif [[ "$PINNED_STATE" == "CLOSED" ]]; then
+        MODE="complete"
+        echo "  ▶  Mode: $MODE  (pinned issue #${PINNED_ISSUE} is closed)"
+      else
+        ISSUE_NUMBER="$PINNED_ISSUE"
+        MODE="implement"
+        echo "  ▶  Mode: $MODE  (Issue #$ISSUE_NUMBER)"
+      fi
     # Pick highest-priority open issue: high-priority label first, then lowest number.
     # PRD mode: --label scopes to prd/<label>; exclude the PRD issue itself (prd) and blocked.
     # Standalone mode: no label filter; additionally exclude any issue carrying a prd/* label.
-    if [[ -n "$FEATURE_LABEL" ]]; then
+    elif [[ -n "$FEATURE_LABEL" ]]; then
       ISSUE_NUMBER=$(gh issue list --repo "$REPO" --state open \
         --label "$FEATURE_LABEL" \
         --json number,labels --limit 100 \
@@ -155,27 +170,31 @@ determine_mode() {
         < /dev/null 2>/dev/null || echo "")
     fi
 
-    if [[ -n "$ISSUE_NUMBER" ]]; then
-      MODE="implement"
-      echo "  ▶  Mode: $MODE  (Issue #$ISSUE_NUMBER)"
-    elif [[ -n "$FEATURE_LABEL" && "$FEATURE_BRANCH" != "main" ]]; then
-      # PRD mode with no remaining task issues — check for an existing feat→main PR
-      FEATURE_PR_COUNT=$(gh pr list --repo "$REPO" --state open \
-        --base "main" \
-        --head "$FEATURE_BRANCH" \
-        --json number --jq 'length' \
-        < /dev/null 2>/dev/null)
+    # The following block only runs in normal (non-pinned) mode; pinned issue routing
+    # is fully handled above.
+    if [[ -z "${PINNED_ISSUE:-}" ]]; then
+      if [[ -n "$ISSUE_NUMBER" ]]; then
+        MODE="implement"
+        echo "  ▶  Mode: $MODE  (Issue #$ISSUE_NUMBER)"
+      elif [[ -n "$FEATURE_LABEL" && "$FEATURE_BRANCH" != "main" ]]; then
+        # PRD mode with no remaining task issues — check for an existing feat→main PR
+        FEATURE_PR_COUNT=$(gh pr list --repo "$REPO" --state open \
+          --base "main" \
+          --head "$FEATURE_BRANCH" \
+          --json number --jq 'length' \
+          < /dev/null 2>/dev/null)
 
-      if [[ "$FEATURE_PR_COUNT" == "0" ]]; then
-        MODE="feature-pr"
-        echo "  ▶  Mode: $MODE  (all task issues closed, opening feat→main PR)"
+        if [[ "$FEATURE_PR_COUNT" == "0" ]]; then
+          MODE="feature-pr"
+          echo "  ▶  Mode: $MODE  (all task issues closed, opening feat→main PR)"
+        else
+          MODE="complete"
+          echo "  ▶  Mode: $MODE  (feat→main PR already open or check failed)"
+        fi
       else
         MODE="complete"
-        echo "  ▶  Mode: $MODE  (feat→main PR already open or check failed)"
+        echo "  ▶  Mode: $MODE  (no open issues or PRs)"
       fi
-    else
-      MODE="complete"
-      echo "  ▶  Mode: $MODE  (no open issues or PRs)"
     fi
   fi
 }

--- a/ralph.sh
+++ b/ralph.sh
@@ -71,7 +71,7 @@ FORK_OWNER="${REPO%%/*}"
 # ── Argument validation ────────────────────────────────────────────────────────
 
 usage() {
-  echo "Usage: $(basename "$0") <max_iterations> [--label=<label>]"
+  echo "Usage: $(basename "$0") <max_iterations> [--label=<label>] [--issue=<N>]"
   echo ""
   echo "  max_iterations  A positive integer — how many Copilot iterations to"
   echo "                  allow before giving up. There is no default; you must"
@@ -81,12 +81,19 @@ usage() {
   echo "                  and FEATURE_LABEL=prd/<label>. When omitted, FEATURE_BRANCH"
   echo "                  defaults to 'main'."
   echo ""
+  echo "  --issue=<N>     Optional issue number. When set, Ralph skips normal issue"
+  echo "                  routing and implements only that specific issue. After the"
+  echo "                  issue is merged, Ralph exits cleanly without opening a"
+  echo "                  feature PR."
+  echo ""
   echo "Examples:"
   echo "  $(basename "$0") 20"
   echo "  $(basename "$0") 20 --label=foo-widget"
+  echo "  $(basename "$0") 20 --issue=82"
+  echo "  $(basename "$0") 20 --issue=82 --label=foo-widget"
 }
 
-if [[ $# -lt 1 || $# -gt 2 ]]; then
+if [[ $# -lt 1 || $# -gt 3 ]]; then
   usage
   exit 1
 fi
@@ -99,16 +106,19 @@ fi
 MAX_ITERATIONS="$1"
 FEATURE_LABEL=""
 FEATURE_BRANCH="main"
+PINNED_ISSUE=""
 
-if [[ $# -eq 2 ]]; then
-  if [[ "$2" =~ ^--label=(.+)$ ]]; then
+for arg in "${@:2}"; do
+  if [[ "$arg" =~ ^--label=(.+)$ ]]; then
     FEATURE_LABEL="prd/${BASH_REMATCH[1]}"
     FEATURE_BRANCH="feat/${BASH_REMATCH[1]}"
+  elif [[ "$arg" =~ ^--issue=([1-9][0-9]*)$ ]]; then
+    PINNED_ISSUE="${BASH_REMATCH[1]}"
   else
     usage
     exit 1
   fi
-fi
+done
 
 # ── Preflight checks ───────────────────────────────────────────────────────────
 
@@ -134,9 +144,10 @@ if [[ -z "$TEST_CMD" ]]; then
   exit 1
 fi
 
-# In PRD mode, validate that either prd/* issues exist or the feature branch already
-# exists on origin. If neither is true, the label is almost certainly a typo.
-if [[ -n "$FEATURE_LABEL" ]]; then
+# In PRD mode (without a pinned issue), validate that either prd/* issues exist or
+# the feature branch already exists on origin. If neither is true, the label is almost
+# certainly a typo.
+if [[ -n "$FEATURE_LABEL" && -z "$PINNED_ISSUE" ]]; then
   if PRD_ISSUE_COUNT=$(gh issue list --repo "$REPO" --state open \
       --label "$FEATURE_LABEL" \
       --json number --jq 'length' \
@@ -151,6 +162,21 @@ if [[ -n "$FEATURE_LABEL" ]]; then
   else
     echo "Warning: Could not reach GitHub API; skipping PRD preflight check."
   fi
+fi
+
+# If a specific issue is pinned, verify it exists and is not already closed.
+if [[ -n "$PINNED_ISSUE" ]]; then
+  PINNED_ISSUE_STATE=$(gh issue view "$PINNED_ISSUE" --repo "$REPO" --json state \
+    --jq '.state' < /dev/null 2>/dev/null || echo "")
+  if [[ -z "$PINNED_ISSUE_STATE" ]]; then
+    echo "Error: Issue #${PINNED_ISSUE} not found in ${REPO}. Check the issue number."
+    exit 1
+  fi
+  if [[ "$PINNED_ISSUE_STATE" == "CLOSED" ]]; then
+    echo "Issue #${PINNED_ISSUE} is already closed. Nothing to do."
+    exit 0
+  fi
+  export PINNED_ISSUE
 fi
 
 # ── Worktree setup ─────────────────────────────────────────────────────────────

--- a/test/helpers/gh
+++ b/test/helpers/gh
@@ -12,6 +12,7 @@
 #   MOCK_PR_VIEW_COMMENTS_RESPONSE  JSON for: gh pr view --json comments
 #   MOCK_PR_VIEW_COMMITS_RESPONSE   JSON for: gh pr view --json commits
 #   MOCK_ISSUE_LIST_RESPONSE      JSON for: gh issue list
+#   MOCK_ISSUE_VIEW_RESPONSE      JSON for: gh issue view <N> --json state
 
 set -euo pipefail
 
@@ -50,6 +51,8 @@ MOCK_FEATURE_PR_LIST_RESPONSE="${MOCK_FEATURE_PR_LIST_RESPONSE:-[]}"
 MOCK_PR_VIEW_COMMENTS_RESPONSE="${MOCK_PR_VIEW_COMMENTS_RESPONSE:-$_default_obj}"
 MOCK_PR_VIEW_COMMITS_RESPONSE="${MOCK_PR_VIEW_COMMITS_RESPONSE:-$_default_commits}"
 MOCK_ISSUE_LIST_RESPONSE="${MOCK_ISSUE_LIST_RESPONSE:-[]}"
+_default_issue_view='{"state":"OPEN"}'
+MOCK_ISSUE_VIEW_RESPONSE="${MOCK_ISSUE_VIEW_RESPONSE:-$_default_issue_view}"
 
 CMD="${POSITIONAL[0]:-}"
 SUBCMD="${POSITIONAL[1]:-}"
@@ -86,6 +89,9 @@ case "$CMD" in
     case "$SUBCMD" in
       list)
         apply_jq "$MOCK_ISSUE_LIST_RESPONSE"
+        ;;
+      view)
+        apply_jq "$MOCK_ISSUE_VIEW_RESPONSE"
         ;;
     esac
     ;;

--- a/test/routing.bats
+++ b/test/routing.bats
@@ -25,7 +25,8 @@ setup() {
         MOCK_REVIEWS_RESPONSE \
         MOCK_PR_LIST_RESPONSE  MOCK_FEATURE_PR_LIST_RESPONSE \
         MOCK_PR_VIEW_COMMENTS_RESPONSE  MOCK_PR_VIEW_COMMITS_RESPONSE \
-        MOCK_ISSUE_LIST_RESPONSE \
+        MOCK_ISSUE_LIST_RESPONSE  MOCK_ISSUE_VIEW_RESPONSE \
+        PINNED_ISSUE \
         || true
 }
 
@@ -225,4 +226,56 @@ setup() {
   determine_mode
 
   [ "$MODE" = "complete" ]
+}
+
+# ─── determine_mode: PINNED_ISSUE ────────────────────────────────────────────
+
+@test "pinned issue: no open PRs, issue is open → implement with correct ISSUE_NUMBER" {
+  export REVIEW_BACKEND=comments
+  export PINNED_ISSUE=82
+  export MOCK_PR_LIST_RESPONSE='[]'
+  export MOCK_ISSUE_VIEW_RESPONSE='{"state":"OPEN"}'
+
+  determine_mode
+
+  [ "$MODE" = "implement" ]
+  [ "$ISSUE_NUMBER" = "82" ]
+}
+
+@test "pinned issue: no open PRs, issue is closed → complete (not feature-pr)" {
+  export REVIEW_BACKEND=comments
+  export PINNED_ISSUE=82
+  export FEATURE_LABEL="prd/some-feature"
+  export FEATURE_BRANCH="feat/some-feature"
+  export MOCK_PR_LIST_RESPONSE='[]'
+  export MOCK_ISSUE_VIEW_RESPONSE='{"state":"CLOSED"}'
+
+  determine_mode
+
+  [ "$MODE" = "complete" ]
+}
+
+@test "pinned issue: open PR exists → normal PR routing (review)" {
+  export REVIEW_BACKEND=comments
+  export PINNED_ISSUE=82
+  export MOCK_PR_LIST_RESPONSE='[{"number":42,"headRefName":"ralph/issue-82"}]'
+  export MOCK_PR_VIEW_COMMENTS_RESPONSE='{"comments":[]}'
+
+  determine_mode
+
+  [ "$MODE" = "review" ]
+  [ "$PR_NUMBER" = "42" ]
+}
+
+@test "pinned issue: no open PRs, issue is open, no label → implement targeting main" {
+  export REVIEW_BACKEND=comments
+  export PINNED_ISSUE=10
+  export FEATURE_BRANCH="main"
+  export MOCK_PR_LIST_RESPONSE='[]'
+  export MOCK_ISSUE_VIEW_RESPONSE='{"state":"OPEN"}'
+
+  determine_mode
+
+  [ "$MODE" = "implement" ]
+  [ "$ISSUE_NUMBER" = "10" ]
 }


### PR DESCRIPTION
This PR implements the `--issue=N` flag for Ralph, allowing users to pin Ralph to a single specific issue rather than relying on the normal issue-picking routing. When `--issue=N` is provided, Ralph skips the `gh issue list` routing and goes directly to `implement` mode for that issue. After the implement → review → fix → merge cycle completes, Ralph exits cleanly without opening a feature PR. The flag can be combined with `--label=foo` to target a specific feature branch, or used alone to target `main`. If the referenced issue is already closed, Ralph exits immediately with a clear message.

Closes ajrussellaudio/ralph#96

## Tasks completed

- ajrussellaudio/ralph#96 feat(single-issue): add --issue=N flag to target a specific issue

## Known limitations

- None identified — all acceptance criteria from the PRD have been addressed.
