### PR TITLE
feat(draft-pr): open draft PR on branch creation and promote in feature-pr mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Draft PR opened automatically on GitHub when `ralph.sh` creates a new feature branch (`feat/`), giving instant visibility that work has started; skipped when resuming an existing branch (#98)
+- `feature-pr` mode now detects an existing draft PR for the feature branch, updates its title and body with the full feature summary, and promotes it from draft to ready-for-review using `gh pr ready`; falls back to creating a new PR if no draft exists (#98)
+
 - `--issue=<N>` flag to `ralph.sh` to pin Ralph to a single specific issue, skipping normal label-based routing; when the issue's PR is merged and closed, Ralph exits cleanly without opening a feature PR (#96)
 - Pinned-issue routing in `determine_mode()` in `lib/routing.sh`: when `PINNED_ISSUE` is set, checks the issue state directly and routes to `implement` (open) or `complete` (closed) (#96)
 - Preflight check in `ralph.sh` that exits immediately with a clear message if the pinned issue is already closed (#96)

--- a/modes/feature-pr.md
+++ b/modes/feature-pr.md
@@ -4,15 +4,17 @@ All task issues under `{{FEATURE_LABEL}}` are closed and all task PRs have been 
 
 ⚠️ **Never** use `gh pr comment --body "..."` — it hangs waiting for stdin. Always write the body to a temp file and use `--body-file <file> < /dev/null`.
 
-## Step 1 — Verify no existing PR
+## Step 1 — Check for existing PR
 
-Check whether a `{{FEATURE_BRANCH}} → main` PR already exists against the upstream repo:
+Check whether any open `{{FEATURE_BRANCH}} → main` PR already exists against the upstream repo (draft or otherwise):
 
 ```bash
-gh pr list --repo {{UPSTREAM_REPO}} --state open --base main --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} --json number --jq '.[].number' < /dev/null
+gh pr list --repo {{UPSTREAM_REPO}} --state open --base main --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} --json number,isDraft --jq '.[0]' < /dev/null
 ```
 
-If one already exists, emit `<promise>STOP</promise>` immediately and do nothing else.
+- If a PR exists and **is not a draft** (i.e. already ready-for-review), emit `<promise>STOP</promise>` immediately and do nothing else.
+- If a PR exists and **is a draft**, note its number — you will update and promote it in Step 3 instead of creating a new one. Continue to Step 2.
+- If no PR exists, you will create a new one in Step 3. Continue to Step 2.
 
 ## Step 2 — Gather context
 
@@ -29,7 +31,7 @@ gh issue list --repo {{REPO}} --state closed --label "{{FEATURE_LABEL}}" --json 
   --jq '[.[] | select(.labels | map(.name) | any(. == "prd") | not)]' < /dev/null
 ```
 
-## Step 3 — Open the pull request
+## Step 3 — Open or update the pull request
 
 Compose a PR description that:
 - Opens with a one-paragraph summary of what the feature does
@@ -37,7 +39,23 @@ Compose a PR description that:
 - Lists every task issue closed as part of this feature (e.g. `- {{REPO}}#12 Short title`)
 - Notes any known limitations or rough edges
 
-Then open the PR:
+Write the description to a temp file (never use `--body "..."` inline).
+
+**If a draft PR already exists** (from Step 1), update its title and body, then promote it to ready-for-review:
+
+```bash
+# Update the title and body
+gh pr edit <draft-pr-number> \
+  --repo {{UPSTREAM_REPO}} \
+  --title "feat(<label>): <short summary>" \
+  --body-file <body-file> \
+  < /dev/null
+
+# Promote from draft to ready-for-review
+gh pr ready <draft-pr-number> --repo {{UPSTREAM_REPO}} < /dev/null
+```
+
+**If no draft PR exists**, create a new one:
 
 ```bash
 gh pr create \
@@ -45,7 +63,7 @@ gh pr create \
   --base main \
   --head {{FORK_OWNER}}:{{FEATURE_BRANCH}} \
   --title "feat(<label>): <short summary>" \
-  --body "<PR description>" \
+  --body-file <body-file> \
   < /dev/null
 ```
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -211,6 +211,20 @@ if [[ "$FEATURE_BRANCH" != "main" ]]; then
     git -C "$GIT_ROOT" fetch origin main > /dev/null
     git -C "$GIT_ROOT" push origin "origin/main:refs/heads/${FEATURE_BRANCH}"
     echo "  ✅  Branch ${FEATURE_BRANCH} created on origin."
+
+    # Open a draft PR so the developer has instant visibility that work has started.
+    DRAFT_PR_BODY="🤖 Ralph is working on this feature. This PR will be updated when all tasks are complete."
+    DRAFT_PR_BODY_FILE=$(mktemp)
+    echo "$DRAFT_PR_BODY" > "$DRAFT_PR_BODY_FILE"
+    gh pr create \
+      --repo "$UPSTREAM_REPO" \
+      --base main \
+      --head "${FORK_OWNER}:${FEATURE_BRANCH}" \
+      --title "${FEATURE_BRANCH}: work in progress" \
+      --body-file "$DRAFT_PR_BODY_FILE" \
+      --draft \
+      < /dev/null && echo "  🚀  Draft PR opened for ${FEATURE_BRANCH}." || echo "  ⚠️   Could not open draft PR (non-fatal)."
+    rm -f "$DRAFT_PR_BODY_FILE"
   fi
 fi
 


### PR DESCRIPTION
This feature adds automatic draft PR creation when Ralph initialises a new feature branch, and updates the `feature-pr` mode to promote that draft to ready-for-review (rather than always opening a brand-new PR). When Ralph pushes a new `feat/<label>` branch, it immediately opens a draft PR on the upstream repo with a placeholder title and body so the developer has instant visibility that work has begun. When all tasks are complete and `feature-pr` mode runs, it detects the existing draft PR, updates the title and body with the full feature summary, and promotes it using `gh pr ready`. If no draft exists (e.g. the branch was created before this feature landed), the mode falls back to creating a new PR as before.

Closes ajrussellaudio/ralph#98

## Tasks completed

- ajrussellaudio/ralph#98 feat(draft-pr): open a draft PR when creating a new feature branch

## Known limitations

- The draft PR title is a literal `feat/: work in progress` (the label is not extracted from `FEATURE_BRANCH` at creation time). This matches the spec wording; a future improvement could strip the `feat/` prefix for a cleaner title.
- `gh pr edit` and `gh pr ready` require write access to the upstream repo — the same requirement as `gh pr create`, so no new permissions are needed.
