### PR TITLE
fix: toml_get silently exits with pipefail when key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `toml_get` no longer silently exits the script when a TOML key is missing; appended `|| true` to the `grep | sed` pipeline so a no-match is not fatal under `set -euo pipefail` (#82)
+
 ### Added
 - Draft PR opened automatically on GitHub when `ralph.sh` creates a new feature branch (`feat/`), giving instant visibility that work has started; skipped when resuming an existing branch (#98)
 - `feature-pr` mode now detects an existing draft PR for the feature branch, updates its title and body with the full feature summary, and promotes it from draft to ready-for-review using `gh pr ready`; falls back to creating a new PR if no draft exists (#98)

--- a/ralph.sh
+++ b/ralph.sh
@@ -47,7 +47,7 @@ fi
 toml_get() {
   [[ -n "$CONFIG_FILE" ]] || return 0
   grep -E "^$1 *=" "$CONFIG_FILE" \
-    | sed -E 's/^[^=]+= *"?([^"]*)"? *$/\1/'
+    | sed -E 's/^[^=]+= *"?([^"]*)"? *$/\1/' || true
 }
 
 BUILD_CMD=$(toml_get build)


### PR DESCRIPTION
Closes #82

## Summary

Fixes `toml_get()` silently exiting the script when a TOML key is absent from `ralph.toml`.

**Root cause:** `grep | sed` pipeline — when `grep` finds no match it exits with code 1. Under `set -euo pipefail`, this propagates up and kills the whole script with no error message.

**Fix:** Append `|| true` to the `grep | sed` pipeline in `toml_get()` so a no-match is treated as an empty result rather than a fatal error.

## Limitations / known rough edges

None — this is a minimal, targeted fix. The function already returns an empty string for missing keys by design; `|| true` simply prevents that empty-string path from being fatal.
