### PR TITLE
feat(draft-pr): push empty init commit before opening draft PR on new feature branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `toml_get` no longer silently exits the script when a TOML key is missing; appended `|| true` to the `grep | sed` pipeline so a no-match is not fatal under `set -euo pipefail` (#82)
 
 ### Added
+- Empty init commit (`chore: initialise feat/<label>`) pushed to the new feature branch before opening the draft PR, ensuring GitHub can create the PR and the branch is immediately distinguishable from `main` (#104)
 - Draft PR opened automatically on GitHub when `ralph.sh` creates a new feature branch (`feat/`), giving instant visibility that work has started; skipped when resuming an existing branch (#98)
 - `feature-pr` mode now detects an existing draft PR for the feature branch, updates its title and body with the full feature summary, and promotes it from draft to ready-for-review using `gh pr ready`; falls back to creating a new PR if no draft exists (#98)
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -212,6 +212,15 @@ if [[ "$FEATURE_BRANCH" != "main" ]]; then
     git -C "$GIT_ROOT" push origin "origin/main:refs/heads/${FEATURE_BRANCH}"
     echo "  ✅  Branch ${FEATURE_BRANCH} created on origin."
 
+    # Push an empty init commit so GitHub allows PR creation and work-start is visible.
+    git -C "$GIT_ROOT" fetch origin "$FEATURE_BRANCH" > /dev/null
+    PARENT_SHA=$(git -C "$GIT_ROOT" rev-parse "origin/${FEATURE_BRANCH}")
+    TREE_SHA=$(git -C "$GIT_ROOT" rev-parse "origin/${FEATURE_BRANCH}^{tree}")
+    EMPTY_COMMIT=$(git -C "$GIT_ROOT" commit-tree "$TREE_SHA" -p "$PARENT_SHA" -m "chore: initialise ${FEATURE_BRANCH}")
+    git -C "$GIT_ROOT" push origin "${EMPTY_COMMIT}:refs/heads/${FEATURE_BRANCH}" > /dev/null
+    git -C "$GIT_ROOT" fetch origin "$FEATURE_BRANCH" > /dev/null
+    echo "  📝  Empty init commit pushed."
+
     # Open a draft PR so the developer has instant visibility that work has started.
     DRAFT_PR_BODY="🤖 Ralph is working on this feature. This PR will be updated when all tasks are complete."
     DRAFT_PR_BODY_FILE=$(mktemp)


### PR DESCRIPTION
Closes #104

## Summary

When Ralph creates a new feature branch (`feat/<label>`), it now pushes an empty initialisation commit before opening the draft PR. This ensures:

- GitHub can create the PR (a branch identical to `main` can still have a PR opened, but the empty commit makes the intent explicit)
- The branch is immediately distinguishable from `main` in the git log
- The commit message follows the convention: `chore: initialise feat/<label>`

## Implementation

Added to the branch-creation block in `ralph.sh` (runs only when the branch is **newly created** — resuming an existing branch skips it entirely):

1. Fetch the newly pushed branch to update the remote-tracking ref
2. Use `git commit-tree` to create an empty commit without requiring a checkout
3. Push the empty commit directly to the remote branch ref
4. Fetch again so the subsequent `worktree add` picks up the correct SHA

`feature-pr.md` already contained the correct logic for detecting an existing draft PR, updating its title/body, and promoting it to ready-for-review — no changes needed there.

## Known limitations

- The empty commit uses the local git user identity configured in the Ralph workspace; no special bot identity is set.
