### PR TITLE
feat(draft-pr): push empty init commit and open draft PR on new feature branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `toml_get` no longer silently exits the script when a TOML key is missing; appended `|| true` to the `grep | sed` pipeline so a no-match is not fatal under `set -euo pipefail` (#82)
 
 ### Added
+- Empty init commit (`chore: initialise feat/<label>`) pushed to the new feature branch before opening the draft PR, ensuring GitHub can create the PR and the branch is immediately distinguishable from `main` (#104)
 - Draft PR opened automatically on GitHub when `ralph.sh` creates a new feature branch (`feat/`), giving instant visibility that work has started; skipped when resuming an existing branch (#98)
 - `feature-pr` mode now detects an existing draft PR for the feature branch, updates its title and body with the full feature summary, and promotes it from draft to ready-for-review using `gh pr ready`; falls back to creating a new PR if no draft exists (#98)
 

--- a/ralph.sh
+++ b/ralph.sh
@@ -212,6 +212,15 @@ if [[ "$FEATURE_BRANCH" != "main" ]]; then
     git -C "$GIT_ROOT" push origin "origin/main:refs/heads/${FEATURE_BRANCH}"
     echo "  ✅  Branch ${FEATURE_BRANCH} created on origin."
 
+    # Push an empty init commit so GitHub allows PR creation and work-start is visible.
+    git -C "$GIT_ROOT" fetch origin "$FEATURE_BRANCH" > /dev/null
+    PARENT_SHA=$(git -C "$GIT_ROOT" rev-parse "origin/${FEATURE_BRANCH}")
+    TREE_SHA=$(git -C "$GIT_ROOT" rev-parse "origin/${FEATURE_BRANCH}^{tree}")
+    EMPTY_COMMIT=$(git -C "$GIT_ROOT" commit-tree "$TREE_SHA" -p "$PARENT_SHA" -m "chore: initialise ${FEATURE_BRANCH}")
+    git -C "$GIT_ROOT" push origin "${EMPTY_COMMIT}:refs/heads/${FEATURE_BRANCH}" > /dev/null
+    git -C "$GIT_ROOT" fetch origin "$FEATURE_BRANCH" > /dev/null
+    echo "  📝  Empty init commit pushed."
+
     # Open a draft PR so the developer has instant visibility that work has started.
     DRAFT_PR_BODY="🤖 Ralph is working on this feature. This PR will be updated when all tasks are complete."
     DRAFT_PR_BODY_FILE=$(mktemp)


### PR DESCRIPTION
## feat(draft-pr): push empty init commit and open draft PR on new feature branch

When Ralph creates a new feature branch (`feat/<label>`), it now immediately pushes an empty initialisation commit and opens a **draft PR** on GitHub, giving the developer instant visibility that work has started. When all tasks are complete and `feature-pr` mode runs, it detects the existing draft PR, updates the title and body with the full feature summary, and promotes it from draft to ready-for-review — rather than always creating a fresh PR from scratch.

Closes ajrussellaudio/ralph#98

### Tasks completed

- ajrussellaudio/ralph#98 feat(draft-pr): open a draft PR when creating a new feature branch
- ajrussellaudio/ralph#104 feat(draft-pr): push empty init commit and open draft PR on new feature branch

### Known limitations / rough edges

- The empty init commit (`chore: initialise feat/<label>`) is included in the commit history until squash-merged; it is harmless but visible.
- If the feature branch was created before this feature landed (i.e. no draft PR exists), `feature-pr` mode falls back to creating a new PR as before — backward compatible but no promotion flow.
- Draft PR detection relies on the branch name match via `gh pr list`; if a non-draft PR was already opened manually for the same branch, the promotion step will be skipped and a second PR will not be created (existing PR is left as-is).
