### PR TITLE
feat(optional-iterations): remove positional max_iterations, add optional --max-iterations flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `--max-iterations=N` optional named flag to `ralph.sh`; when omitted Ralph runs in an unlimited `while true` loop until a clean exit condition is reached (#89)
+- Migration error message when a bare positional integer is passed (old interface): `"The positional <max_iterations> argument has been removed. Use --max-iterations=N instead."` (#89)
+- `RALPH_PARSE_ONLY=1` test hook in `ralph.sh` to allow arg-parsing bats tests without requiring a full preflight environment (#89)
+- `test/arg-parsing.bats`: 9 bats tests covering all arg-parsing scenarios for the new `--max-iterations` flag (#89)
+
+### Changed
+- Removed mandatory positional `<max_iterations>` argument from `ralph.sh`; `--max-iterations=N` is now optional (#89)
+- Terminal header shows `Max iterations: unlimited` when no cap is set, `Max iterations: N` when `--max-iterations=N` is passed (#89)
+- Iteration counter shows `iteration N` when uncapped, `iteration N / M` when capped (#89)
+- `usage()` function updated to reflect the new interface (#89)
+- README usage examples updated to show the new `--max-iterations=N` flag (#89)
+
 ### Changed
 - `review.md` now reads all prior `<!-- RALPH-REVIEW: REQUEST_CHANGES -->` and `<!-- RALPH-FIX: RESPONSE -->` comments before delegating to the review sub-agent, providing full multi-round context (#86)
 - After a fix (new commits pushed after a `REQUEST_CHANGES` comment), `determine_mode()` HTML path now routes to `review` instead of `review-round2` (#86)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ Each iteration Ralph:
 
 3. **Run from your project root:**
    ```bash
-   ralph 20
+   ralph
    # or, to work within a feature branch:
-   ralph 20 --label=foo-widget
+   ralph --label=foo-widget
+   # or, to cap the number of iterations:
+   ralph --max-iterations=20 --label=foo-widget
    ```
-   Replace `20` with however many iterations you want to allow.
+   Ralph runs indefinitely by default, stopping only when all tasks are complete.
+   Use `--max-iterations=N` as an escape hatch if you want a hard cap.
 
 4. **Update Ralph at any time:**
    ```bash

--- a/ralph.sh
+++ b/ralph.sh
@@ -2,11 +2,12 @@
 # Ralph — Long-running Copilot CLI agent loop with bash-side mode routing
 #
 # Usage:
-#   ./ralph.sh <max_iterations> [--label=<label>]
+#   ./ralph.sh [--max-iterations=N] [--label=<label>] [--issue=<N>]
 #
 # Examples:
-#   ./ralph.sh 20
-#   ./ralph.sh 20 --label=foo-widget
+#   ./ralph.sh --label=foo-widget
+#   ./ralph.sh --max-iterations=20 --label=foo-widget
+#   ./ralph.sh --max-iterations=20 --issue=82
 #
 # Each iteration:
 #   1. Checks GitHub for open ralph PRs or open issues (in bash)
@@ -71,45 +72,43 @@ FORK_OWNER="${REPO%%/*}"
 # ── Argument validation ────────────────────────────────────────────────────────
 
 usage() {
-  echo "Usage: $(basename "$0") <max_iterations> [--label=<label>] [--issue=<N>]"
+  echo "Usage: $(basename "$0") [--max-iterations=N] [--label=<label>] [--issue=<N>]"
   echo ""
-  echo "  max_iterations  A positive integer — how many Copilot iterations to"
-  echo "                  allow before giving up. There is no default; you must"
-  echo "                  decide how many loops is reasonable for your task."
+  echo "  --max-iterations=N  Optional positive integer — how many Copilot iterations"
+  echo "                      to allow before giving up. When omitted, Ralph runs"
+  echo "                      indefinitely until a clean exit condition is reached."
   echo ""
-  echo "  --label=<label> Optional feature label. Derives FEATURE_BRANCH=feat/<label>"
-  echo "                  and FEATURE_LABEL=prd/<label>. When omitted, FEATURE_BRANCH"
-  echo "                  defaults to 'main'."
+  echo "  --label=<label>     Optional feature label. Derives FEATURE_BRANCH=feat/<label>"
+  echo "                      and FEATURE_LABEL=prd/<label>. When omitted, FEATURE_BRANCH"
+  echo "                      defaults to 'main'."
   echo ""
-  echo "  --issue=<N>     Optional issue number. When set, Ralph skips normal issue"
-  echo "                  routing and implements only that specific issue. After the"
-  echo "                  issue is merged, Ralph exits cleanly without opening a"
-  echo "                  feature PR."
+  echo "  --issue=<N>         Optional issue number. When set, Ralph skips normal issue"
+  echo "                      routing and implements only that specific issue. After the"
+  echo "                      issue is merged, Ralph exits cleanly without opening a"
+  echo "                      feature PR."
   echo ""
   echo "Examples:"
-  echo "  $(basename "$0") 20"
-  echo "  $(basename "$0") 20 --label=foo-widget"
-  echo "  $(basename "$0") 20 --issue=82"
-  echo "  $(basename "$0") 20 --issue=82 --label=foo-widget"
+  echo "  $(basename "$0")"
+  echo "  $(basename "$0") --label=foo-widget"
+  echo "  $(basename "$0") --max-iterations=20 --label=foo-widget"
+  echo "  $(basename "$0") --max-iterations=20 --issue=82 --label=foo-widget"
 }
 
-if [[ $# -lt 1 || $# -gt 3 ]]; then
-  usage
-  exit 1
-fi
-
-if ! [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
-  usage
-  exit 1
-fi
-
-MAX_ITERATIONS="$1"
+MAX_ITERATIONS=""
 FEATURE_LABEL=""
 FEATURE_BRANCH="main"
 PINNED_ISSUE=""
 
-for arg in "${@:2}"; do
-  if [[ "$arg" =~ ^--label=(.+)$ ]]; then
+for arg in "$@"; do
+  if [[ "$arg" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: The positional <max_iterations> argument has been removed. Use --max-iterations=N instead."
+    exit 1
+  elif [[ "$arg" =~ ^--max-iterations=([1-9][0-9]*)$ ]]; then
+    MAX_ITERATIONS="${BASH_REMATCH[1]}"
+  elif [[ "$arg" =~ ^--max-iterations(=.*)?$ ]]; then
+    usage
+    exit 1
+  elif [[ "$arg" =~ ^--label=(.+)$ ]]; then
     FEATURE_LABEL="prd/${BASH_REMATCH[1]}"
     FEATURE_BRANCH="feat/${BASH_REMATCH[1]}"
   elif [[ "$arg" =~ ^--issue=([1-9][0-9]*)$ ]]; then
@@ -119,6 +118,15 @@ for arg in "${@:2}"; do
     exit 1
   fi
 done
+
+# Test hook: exit 0 after successful arg parsing so bats tests can verify
+# arg handling without requiring a full preflight environment.
+if [[ "${RALPH_PARSE_ONLY:-}" == "1" ]]; then
+  echo "MAX_ITERATIONS=${MAX_ITERATIONS}"
+  echo "FEATURE_BRANCH=${FEATURE_BRANCH}"
+  echo "PINNED_ISSUE=${PINNED_ISSUE}"
+  exit 0
+fi
 
 # ── Preflight checks ───────────────────────────────────────────────────────────
 
@@ -274,20 +282,34 @@ detect_review_backend
 echo ""
 echo "╔══════════════════════════════════════════════════════════════╗"
 echo "║  Ralph — Copilot agentic loop                                ║"
-echo "║  Max iterations: $MAX_ITERATIONS$(printf '%*s' $((46 - ${#MAX_ITERATIONS})) '')║"
+if [[ -n "$MAX_ITERATIONS" ]]; then
+  echo "║  Max iterations: $MAX_ITERATIONS$(printf '%*s' $((46 - ${#MAX_ITERATIONS})) '')║"
+else
+  echo "║  Max iterations: unlimited                                   ║"
+fi
 echo "╚══════════════════════════════════════════════════════════════╝"
 
-for i in $(seq 1 "$MAX_ITERATIONS"); do
+run_loop() {
+  local i="$1"
   echo ""
   printf "\033[1;36m"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  🤖 Ralph — iteration $i / $MAX_ITERATIONS"
+  if [[ -n "$MAX_ITERATIONS" ]]; then
+    echo "  🤖 Ralph — iteration $i / $MAX_ITERATIONS"
+  else
+    echo "  🤖 Ralph — iteration $i"
+  fi
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   printf "\033[0m"
 
   # Update terminal tab/window title and tmux window name.
-  printf "\033]0;🤖 Ralph — iteration %s / %s\007" "$i" "$MAX_ITERATIONS"
-  printf "\033k🤖 Ralph %s/%s\033\\" "$i" "$MAX_ITERATIONS"
+  if [[ -n "$MAX_ITERATIONS" ]]; then
+    printf "\033]0;🤖 Ralph — iteration %s / %s\007" "$i" "$MAX_ITERATIONS"
+    printf "\033k🤖 Ralph %s/%s\033\\" "$i" "$MAX_ITERATIONS"
+  else
+    printf "\033]0;🤖 Ralph — iteration %s\007" "$i"
+    printf "\033k🤖 Ralph %s\033\\" "$i"
+  fi
 
   MODE=""
   determine_mode
@@ -297,7 +319,11 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     echo ""
     printf "\033[1;32m"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "  ✅  Ralph completed all tasks at iteration $i / $MAX_ITERATIONS"
+    if [[ -n "$MAX_ITERATIONS" ]]; then
+      echo "  ✅  Ralph completed all tasks at iteration $i / $MAX_ITERATIONS"
+    else
+      echo "  ✅  Ralph completed all tasks at iteration $i"
+    fi
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     printf "\033[0m"
     exit 0
@@ -319,7 +345,11 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     echo ""
     printf "\033[1;32m"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "  ✅  Ralph completed all tasks at iteration $i / $MAX_ITERATIONS"
+    if [[ -n "$MAX_ITERATIONS" ]]; then
+      echo "  ✅  Ralph completed all tasks at iteration $i / $MAX_ITERATIONS"
+    else
+      echo "  ✅  Ralph completed all tasks at iteration $i"
+    fi
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     printf "\033[0m"
     exit 0
@@ -327,13 +357,31 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 
   if echo "$OUTPUT" | grep -q "<promise>STOP</promise>"; then
     echo ""
-    echo "  ✔  Iteration $i / $MAX_ITERATIONS done — restarting"
+    if [[ -n "$MAX_ITERATIONS" ]]; then
+      echo "  ✔  Iteration $i / $MAX_ITERATIONS done — restarting"
+    else
+      echo "  ✔  Iteration $i done — restarting"
+    fi
   fi
 
-  echo ""
-  echo "  Iteration $i done. $(( MAX_ITERATIONS - i )) iteration(s) remaining."
+  if [[ -n "$MAX_ITERATIONS" ]]; then
+    echo ""
+    echo "  Iteration $i done. $(( MAX_ITERATIONS - i )) iteration(s) remaining."
+  fi
   sleep 2
-done
+}
+
+if [[ -n "$MAX_ITERATIONS" ]]; then
+  for i in $(seq 1 "$MAX_ITERATIONS"); do
+    run_loop "$i"
+  done
+else
+  i=0
+  while true; do
+    i=$(( i + 1 ))
+    run_loop "$i"
+  done
+fi
 
 # ── Max iterations reached ─────────────────────────────────────────────────────
 

--- a/test/arg-parsing.bats
+++ b/test/arg-parsing.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# Tests for ralph.sh argument parsing.
+#
+# Uses RALPH_PARSE_ONLY=1 to exit after parsing without running preflight
+# checks or the main loop, so tests are fast and self-contained.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+RALPH="$REPO_ROOT/ralph.sh"
+
+# ─── No --max-iterations flag ─────────────────────────────────────────────────
+
+@test "no args: parses successfully with unlimited iterations" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "MAX_ITERATIONS="
+  # MAX_ITERATIONS should be empty (unlimited)
+  echo "$output" | grep -q "^MAX_ITERATIONS=$"
+}
+
+@test "--label only: parses successfully, FEATURE_BRANCH derived" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --label=foo-widget
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "FEATURE_BRANCH=feat/foo-widget"
+}
+
+# ─── --max-iterations flag ────────────────────────────────────────────────────
+
+@test "--max-iterations=10: parses successfully, MAX_ITERATIONS set" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --max-iterations=10
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "MAX_ITERATIONS=10"
+}
+
+@test "--max-iterations=1: minimum valid value accepted" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --max-iterations=1
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "MAX_ITERATIONS=1"
+}
+
+# ─── --max-iterations invalid values ─────────────────────────────────────────
+
+@test "--max-iterations=0: exits with usage error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --max-iterations=0
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "usage\|--max-iterations"
+}
+
+@test "--max-iterations=foo: exits with usage error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --max-iterations=foo
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "usage\|--max-iterations"
+}
+
+@test "--max-iterations without value: exits with usage error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --max-iterations
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "usage\|--max-iterations"
+}
+
+# ─── Old positional interface ─────────────────────────────────────────────────
+
+@test "positional integer (old interface): exits with migration error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" 40
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "positional"
+  echo "$output" | grep -q "\-\-max-iterations"
+}
+
+# ─── Unknown flags ────────────────────────────────────────────────────────────
+
+@test "unknown flag: exits with usage error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" --unknown-flag
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "usage\|--max-iterations"
+}


### PR DESCRIPTION
Closes #89

## Summary

Replaces the mandatory positional `<max_iterations>` argument with an optional `--max-iterations=N` named flag. Ralph now runs indefinitely by default, stopping only when a clean exit condition is reached.

### Changes

- **Argument parsing**: Removed positional `<max_iterations>`; added `--max-iterations=N` optional flag
- **Main loop**: `while true` when uncapped; `for i in $(seq 1 N)` when capped
- **Iteration counter**: Shows `iteration N` when uncapped, `iteration N / M` when capped
- **Terminal header**: Shows `Max iterations: unlimited` or `Max iterations: N`
- **Migration error**: Passing a bare integer (old interface) exits with a clear message: _"The positional `<max_iterations>` argument has been removed. Use `--max-iterations=N` instead."_
- **Tests**: 9 new bats tests in `test/arg-parsing.bats` covering all arg-parsing scenarios
- **README + usage()**: Updated to reflect the new interface

### Known limitations / rough edges

- The `RALPH_PARSE_ONLY=1` test hook exits 0 after arg parsing but before preflight; it's a deliberate testing affordance, not a user-facing feature.
