### PR TITLE
feat(run): replace ad-hoc preflight with ralph_doctor() (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ralph doctor` subcommand dispatched from `ralph.sh` (#117)
 - `test/doctor.bats`: bats tests covering all-pass, each hard failure in isolation, each warning in isolation, multiple simultaneous failures, mix of warnings and failures, and exit code behaviour (#117)
 
+### Changed
+- `ralph run` preflight now calls `ralph_doctor()` instead of the old ad-hoc checks; aborts with exit 1 if any hard failure is found (#118)
+- Missing `test` command in `ralph.toml` is now a ⚠️ warning (not a hard error) in both `ralph doctor` and `ralph run` (#118)
+
 - `ralph status` issues section: lists all open in-scope issues with number and title; blocked issues marked with ⚠️; placeholder shown when none (#113)
 - `ralph status --label=foo` filters issues to those labelled `prd/foo`; without `--label`, shows all issues excluding `prd/*`-labelled ones (#113)
 - `ralph status --label=foo` feature PR section: shows the `feat/foo` → main aggregate PR (number, branch, review state, CI) when one exists; omitted entirely when none (#113)

--- a/ralph.sh
+++ b/ralph.sh
@@ -200,27 +200,11 @@ if [[ "${RALPH_PARSE_ONLY:-}" == "1" ]]; then
   exit 0
 fi
 
-# ── Preflight checks ───────────────────────────────────────────────────────────
+# ── Preflight checks (via ralph_doctor) ───────────────────────────────────────
 
-if ! command -v copilot &>/dev/null; then
-  echo "Error: 'copilot' not found in PATH. Install the GitHub Copilot CLI first."
-  exit 1
-fi
-
-if [[ ! -d "$MODES_DIR" ]]; then
-  echo "Error: Modes directory not found at $MODES_DIR"
-  exit 1
-fi
-
-if [[ -z "$REPO" ]]; then
-  echo "Error: Could not determine the GitHub repo. Add 'repo = \"owner/repo\"' to"
-  echo "ralph.toml in your project root, or run from inside a GitHub repository."
-  exit 1
-fi
-
-if [[ -z "$TEST_CMD" ]]; then
-  echo "Error: No test command configured. Add 'test = \"your-test-cmd\"' to"
-  echo "ralph.toml in your project root (create it from ~/.ralph/project.example.toml)."
+# shellcheck source=lib/doctor.sh
+source "$SCRIPT_DIR/lib/doctor.sh"
+if ! ralph_doctor; then
   exit 1
 fi
 


### PR DESCRIPTION
Closes #118

## What was implemented

Replaced the old ad-hoc preflight block in `ralph run` with a call to `ralph_doctor()` from `lib/doctor.sh`.

**Changes:**
- Removed the manual inline checks for `copilot`, modes directory, repo, and `TEST_CMD` from `ralph.sh`
- `ralph run` now sources `lib/doctor.sh` and calls `ralph_doctor()` before the agent loop
- If `ralph_doctor()` returns non-zero (any hard failure), `ralph run` aborts with exit 1 — no extra output beyond what doctor already printed
- Missing `test` command is now a ⚠️ warning (not a hard error), matching the PRD decision

**`ralph doctor` subcommand** was already wired up in #117 — no dispatch changes needed.

## TEST_CMD audit

Mode files (`implement.md`, `fix.md`, `fix-bot.md`, `review.md`, `merge.md`) reference `{{TEST_CMD}}` as a template placeholder. At runtime `ralph.sh` substitutes the placeholder via:

```bash
PROMPT="${PROMPT//\{\{TEST_CMD\}\}/$TEST_CMD}"
```

If `TEST_CMD` is empty the substitution produces an empty backtick span (e.g. `` Run `` ``). The `implement.md` prompt already instructs agents to skip empty commands via the `(skip if empty)` qualifier on `{{BUILD_CMD}}`; agents handle the equivalent empty `{{TEST_CMD}}` the same way in practice. No mode file changes are required — the ⚠️ from `ralph doctor` is sufficient signal.

## Limitations / known rough edges

- Mode files do not explicitly say "(skip if empty)" for `{{TEST_CMD}}`; a follow-up could add that wording for clarity.
- Context-specific validation (`--label`, `--issue`) is unchanged and still runs after doctor in `ralph run`.

All 77 existing bats tests pass.
