### PR TITLE
feat(ralph-init): guided prompt sequence, file writing, and subcommand dispatch (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `lib/doctor.sh` with `ralph_doctor()`: audits 9 environment checks (copilot in PATH, gh in PATH, gh authenticated, repo resolvable, modes directory present, ralph.toml present, test/build commands configured, GitHub API reachable); prints ✅/⚠️/❌ per check with fix hints; exits 0 if no hard failures, 1 if any occur (#117)
 - `ralph doctor` subcommand dispatched from `ralph.sh` (#117)
 - `test/doctor.bats`: bats tests covering all-pass, each hard failure in isolation, each warning in isolation, multiple simultaneous failures, mix of warnings and failures, and exit code behaviour (#117)
+- `lib/init.sh` with `ralph_init()`: guided prompt sequence to scaffold `ralph.toml`; infers `repo` from `gh repo view`; prompts for all four fields with descriptions and defaults; shows file preview in a `━━━` box with `Write this file? [Y/n]` confirmation; writes file with inline comments matching `project.example.toml` style; calls `ralph_doctor()` after a successful write (#122)
+- `ralph init` subcommand dispatched from `ralph.sh` (#122)
+- `test/init.bats`: bats tests covering all-defaults accepted, user overrides, blank upstream, declined preview, file comments, repo inference, and doctor call (#122)
 
 ### Changed
 - `ralph run` preflight now calls `ralph_doctor()` instead of the old ad-hoc checks; aborts with exit 1 if any hard failure is found (#118)

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# init.sh — ralph_init(): guided prompt sequence to scaffold ralph.toml.
+#
+# Sourced by ralph.sh and by bats unit tests (with RALPH_TESTING=1).
+#
+# Expects SCRIPT_DIR to be set by the caller (ralph.sh or tests).
+
+ralph_init() {
+  local rule="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "$rule"
+  echo "🚀 Ralph — init"
+  echo "$rule"
+  echo ""
+  echo "  Let's configure your project. Press Enter to accept each default."
+  echo ""
+
+  # ── Field 1: repo ────────────────────────────────────────────────────────────
+
+  local inferred_repo=""
+  if command -v gh >/dev/null 2>&1; then
+    inferred_repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
+  fi
+
+  local repo_default="${inferred_repo:-}"
+  if [[ -n "$repo_default" ]]; then
+    echo "  repo  GitHub repo slug (owner/repo). [${repo_default}]"
+  else
+    echo "  repo  GitHub repo slug (owner/repo). []"
+  fi
+  printf "  > "
+  local repo_value
+  read -r repo_value
+  if [[ -z "$repo_value" ]]; then
+    repo_value="$repo_default"
+  fi
+
+  # ── Field 2: upstream ────────────────────────────────────────────────────────
+
+  echo ""
+  echo "  upstream  Upstream repo slug for fork workflows — Ralph does his work on"
+  echo "            your fork but the final feature PR lands on the upstream repo."
+  echo "            Leave blank for personal projects (defaults to repo). []"
+  printf "  > "
+  local upstream_value
+  read -r upstream_value
+
+  # ── Field 3: build ───────────────────────────────────────────────────────────
+
+  echo ""
+  echo "  build  Build command — leave empty if no build step. []"
+  printf "  > "
+  local build_value
+  read -r build_value
+
+  # ── Field 4: test ────────────────────────────────────────────────────────────
+
+  echo ""
+  echo "  test  Test command — required for Ralph to validate changes. []"
+  printf "  > "
+  local test_value
+  read -r test_value
+
+  # ── File preview ─────────────────────────────────────────────────────────────
+
+  local file_contents
+  file_contents=$(cat <<TOML
+# Ralph project configuration
+# Copy this file to ralph.toml at your project root and fill in the values.
+
+# GitHub repo slug (owner/repo). Optional — Ralph infers it from \`gh repo view\`.
+repo = "${repo_value}"
+
+# Upstream repo slug (owner/repo). Optional — for fork-based workflows where
+# Ralph does all his work on your fork but the final feature PR should land on
+# the upstream repo. Defaults to \`repo\` when not set (personal project behaviour
+# unchanged).
+upstream = "${upstream_value}"
+
+# Build command — leave empty if no build step.
+build = "${build_value}"
+
+# Test command — required.
+test = "${test_value}"
+TOML
+)
+
+  echo ""
+  echo "$rule"
+  echo "  📄  ralph.toml preview"
+  echo "$rule"
+  echo ""
+  echo "$file_contents"
+  echo ""
+  echo "$rule"
+  echo ""
+
+  # ── Confirmation ─────────────────────────────────────────────────────────────
+
+  printf "  Write this file? [Y/n] "
+  local confirm_value
+  read -r confirm_value
+
+  if [[ "$confirm_value" =~ ^[Nn] ]]; then
+    echo ""
+    echo "  Aborted. No file written."
+    return 0
+  fi
+
+  # ── Write file ───────────────────────────────────────────────────────────────
+
+  local output_path="${INIT_OUTPUT_DIR:-$GIT_ROOT}/ralph.toml"
+  printf '%s\n' "$file_contents" > "$output_path"
+
+  echo ""
+  echo "  ✅  Written: $output_path"
+  echo ""
+
+  # ── Post-write: call doctor or print nudge ───────────────────────────────────
+
+  local doctor_lib="${SCRIPT_DIR:-}/lib/doctor.sh"
+  if [[ -f "$doctor_lib" ]]; then
+    # shellcheck source=lib/doctor.sh
+    source "$doctor_lib"
+    ralph_doctor || true
+  else
+    echo "  Run \`ralph doctor\` to validate your environment."
+  fi
+}

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -60,6 +60,13 @@ ralph_init() {
   local test_value
   read -r test_value
 
+  # ── Sanitize values for TOML string interpolation (escape \ then ") ─────────
+
+  local repo_safe="${repo_value//\\/\\\\}";         repo_safe="${repo_safe//\"/\\\"}"
+  local upstream_safe="${upstream_value//\\/\\\\}"; upstream_safe="${upstream_safe//\"/\\\"}"
+  local build_safe="${build_value//\\/\\\\}";       build_safe="${build_safe//\"/\\\"}"
+  local test_safe="${test_value//\\/\\\\}";         test_safe="${test_safe//\"/\\\"}"
+
   # ── File preview ─────────────────────────────────────────────────────────────
 
   local file_contents
@@ -68,19 +75,19 @@ ralph_init() {
 # Copy this file to ralph.toml at your project root and fill in the values.
 
 # GitHub repo slug (owner/repo). Optional — Ralph infers it from \`gh repo view\`.
-repo = "${repo_value}"
+repo = "${repo_safe}"
 
 # Upstream repo slug (owner/repo). Optional — for fork-based workflows where
 # Ralph does all his work on your fork but the final feature PR should land on
 # the upstream repo. Defaults to \`repo\` when not set (personal project behaviour
 # unchanged).
-upstream = "${upstream_value}"
+upstream = "${upstream_safe}"
 
 # Build command — leave empty if no build step.
-build = "${build_value}"
+build = "${build_safe}"
 
 # Test command — required.
-test = "${test_value}"
+test = "${test_safe}"
 TOML
 )
 
@@ -109,6 +116,19 @@ TOML
   # ── Write file ───────────────────────────────────────────────────────────────
 
   local output_path="${INIT_OUTPUT_DIR:-$GIT_ROOT}/ralph.toml"
+
+  if [[ -f "$output_path" ]]; then
+    echo ""
+    printf "  ⚠️  %s already exists. Overwrite? [y/N] " "$output_path"
+    local overwrite_value
+    read -r overwrite_value
+    if [[ ! "$overwrite_value" =~ ^[Yy]$ ]]; then
+      echo ""
+      echo "  Aborted. Existing file kept."
+      return 0
+    fi
+  fi
+
   printf '%s\n' "$file_contents" > "$output_path"
 
   echo ""

--- a/ralph.sh
+++ b/ralph.sh
@@ -83,6 +83,9 @@ elif [[ "$1" == "status" ]]; then
 elif [[ "$1" == "doctor" ]]; then
   SUBCOMMAND="doctor"
   shift
+elif [[ "$1" == "init" ]]; then
+  SUBCOMMAND="init"
+  shift
 elif [[ "$1" =~ ^-- ]]; then
   echo "Error: '$1' requires a subcommand. Did you mean: ralph run $*"
   echo "Use 'ralph run' to start the agent loop."
@@ -96,6 +99,7 @@ else
   echo "  run     Start the Copilot agent loop"
   echo "  status  Show status of the current feature"
   echo "  doctor  Check environment health"
+  echo "  init    Scaffold a ralph.toml configuration file"
   exit 1
 fi
 
@@ -138,6 +142,20 @@ if [[ "$SUBCOMMAND" == "doctor" ]]; then
   # shellcheck source=lib/doctor.sh
   source "$SCRIPT_DIR/lib/doctor.sh"
   ralph_doctor
+  exit $?
+fi
+
+# ── Init handler ───────────────────────────────────────────────────────────────
+
+if [[ "$SUBCOMMAND" == "init" ]]; then
+  if [[ "${RALPH_PARSE_ONLY:-}" == "1" ]]; then
+    echo "SUBCOMMAND=init"
+    exit 0
+  fi
+
+  # shellcheck source=lib/init.sh
+  source "$SCRIPT_DIR/lib/init.sh"
+  ralph_init
   exit $?
 fi
 

--- a/test/init.bats
+++ b/test/init.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# Tests for ralph_init() in lib/init.sh.
+#
+# Uses RALPH_TESTING=1, temp directories for file output, and stdin injection
+# via heredocs to simulate user input at each prompt.
+#
+# Prompt sequence: repo → upstream → build → test → confirmation (5 reads).
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  export PATH="$REPO_ROOT/test/helpers:$PATH"
+
+  # Source init function into this shell.
+  # shellcheck source=../lib/init.sh
+  source "$REPO_ROOT/lib/init.sh"
+
+  export RALPH_TESTING=1
+  export SCRIPT_DIR="$REPO_ROOT"
+  export GIT_ROOT="$BATS_TEST_TMPDIR"
+  export INIT_OUTPUT_DIR="$BATS_TEST_TMPDIR"
+
+  # Default mock: gh repo view returns owner/repo.
+  unset MOCK_REPO_VIEW_RESPONSE MOCK_REPO_VIEW_EXIT || true
+}
+
+# Helper: run ralph_init with five lines of stdin input.
+# Usage: _run_init "repo" "upstream" "build" "test" "confirm"
+_run_init() {
+  local repo_input="$1"
+  local upstream_input="$2"
+  local build_input="$3"
+  local test_input="$4"
+  local confirm_input="$5"
+  run ralph_init <<< "$(printf '%s\n' \
+    "$repo_input" \
+    "$upstream_input" \
+    "$build_input" \
+    "$test_input" \
+    "$confirm_input")"
+}
+
+# ─── Header ───────────────────────────────────────────────────────────────────
+
+@test "init: output contains Ralph header" {
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "Ralph"
+}
+
+@test "init: output uses box style (━━━)" {
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "━━━"
+}
+
+# ─── All defaults accepted ────────────────────────────────────────────────────
+
+@test "init: all defaults accepted → file written with inferred repo, blank build/test" {
+  # Enter for all fields → accept defaults; Y to confirm.
+  _run_init "" "" "" "" "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'repo = "owner/repo"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'upstream = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'build = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── User overrides repo and test ─────────────────────────────────────────────
+
+@test "init: user overrides repo and test → file contains typed values" {
+  _run_init "myorg/myrepo" "" "" "npm test" "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'repo = "myorg/myrepo"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "npm test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Upstream left blank ──────────────────────────────────────────────────────
+
+@test "init: upstream left blank → field written as empty string" {
+  _run_init "" "" "" "" "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'upstream = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Decline preview → file not written ──────────────────────────────────────
+
+@test "init: 'n' at preview → file not written, clean exit" {
+  _run_init "" "" "" "" "n"
+  [ "$status" -eq 0 ]
+  [ ! -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+}
+
+@test "init: 'N' at preview → file not written, clean exit" {
+  _run_init "" "" "" "" "N"
+  [ "$status" -eq 0 ]
+  [ ! -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+}
+
+# ─── File preview shown before writing ───────────────────────────────────────
+
+@test "init: file preview shown before confirmation" {
+  _run_init "preview/test" "" "" "" "n"
+  echo "$output" | grep -q "ralph.toml preview"
+  echo "$output" | grep -q 'repo = "preview/test"'
+}
+
+# ─── Written file includes inline comments ───────────────────────────────────
+
+@test "init: written file includes inline comments matching example style" {
+  _run_init "" "" "" "" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q "# GitHub repo slug" "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q "# Upstream repo slug" "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q "# Build command" "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q "# Test command" "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Repo inferred from gh repo view ─────────────────────────────────────────
+
+@test "init: repo default is inferred from gh repo view" {
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "owner/repo"
+}
+
+@test "init: gh inference fails → blank default offered" {
+  export MOCK_REPO_VIEW_EXIT=1
+  _run_init "" "" "" "" "n"
+  [ "$status" -eq 0 ]
+  # Should still complete without error (blank default used).
+  echo "$output" | grep -q "repo"
+}
+
+# ─── ralph_doctor called after successful write ───────────────────────────────
+
+@test "init: ralph_doctor called after successful write (or nudge printed)" {
+  _run_init "" "" "" "" "Y"
+  [ "$status" -eq 0 ]
+  # Either ralph_doctor output (contains "🩺 Ralph — doctor") or nudge message.
+  (echo "$output" | grep -q "🩺 Ralph" || echo "$output" | grep -q "ralph doctor")
+}
+
+# ─── Subcommand dispatch integration ──────────────────────────────────────────
+
+@test "ralph.sh init: subcommand dispatches correctly" {
+  run "$REPO_ROOT/ralph.sh" init <<< "$(printf '%s\n' "" "" "" "" "n")"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Ralph"
+}

--- a/test/init.bats
+++ b/test/init.bats
@@ -132,6 +132,41 @@ _run_init() {
   echo "$output" | grep -q "repo"
 }
 
+# ─── Special character escaping ──────────────────────────────────────────────
+
+@test "init: double-quote in repo value is escaped in written file" {
+  _run_init 'org/repo"hack' "" "" "" "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -qF 'repo = "org/repo\"hack"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: backslash in test value is escaped in written file" {
+  _run_init "" "" "" 'npm run test\spec' "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -qF 'test = "npm run test\\spec"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Overwrite protection ─────────────────────────────────────────────────────
+
+@test "init: existing ralph.toml → warns user, keeps file if declined" {
+  echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "" "" "" "" "Y" "n")"
+  [ "$status" -eq 0 ]
+  grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
+  echo "$output" | grep -q "already exists"
+}
+
+@test "init: existing ralph.toml → overwrites when user confirms" {
+  echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "" "" "" "" "Y" "y")"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  ! grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'repo = "' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
 # ─── ralph_doctor called after successful write ───────────────────────────────
 
 @test "init: ralph_doctor called after successful write (or nudge printed)" {


### PR DESCRIPTION
Closes #122

## What was implemented

- **`lib/init.sh`** — `ralph_init()` function with a guided prompt sequence:
  - Prompts for `repo`, `upstream`, `build`, `test` one at a time, each showing the field name, short description, and default in brackets
  - `repo` default is inferred from `gh repo view --json nameWithOwner`; falls back to blank if inference fails
  - Press Enter to accept the default; type to override
  - Shows a full `ralph.toml` preview in a `━━━` box before writing
  - `Write this file? [Y/n]` confirmation — declining exits cleanly without writing
  - Written file includes inline comments matching `project.example.toml` style
  - Calls `ralph_doctor()` after a successful write (or prints a nudge if `lib/doctor.sh` is unavailable)
  - Uses Ralph's emoji/box output style throughout

- **`ralph.sh`** — `ralph init` subcommand wired into the dispatch layer

- **`test/init.bats`** — 13 bats tests covering all acceptance criteria cases

## All 90 tests pass

## Limitations / known rough edges

- Project-type detection (auto-detecting build/test commands) is deferred to a follow-on slice per the issue spec
- Overwrite safety (detecting an existing `ralph.toml`) is also deferred to a follow-on slice
