### PR TITLE
feat(init): project-type detection for build/test defaults (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `lib/init.sh` with `ralph_init()`: guided prompt sequence to scaffold `ralph.toml`; infers `repo` from `gh repo view`; prompts for all four fields with descriptions and defaults; shows file preview in a `━━━` box with `Write this file? [Y/n]` confirmation; writes file with inline comments matching `project.example.toml` style; calls `ralph_doctor()` after a successful write (#122)
 - `ralph init` subcommand dispatched from `ralph.sh` (#122)
 - `test/init.bats`: bats tests covering all-defaults accepted, user overrides, blank upstream, declined preview, file comments, repo inference, and doctor call (#122)
+- Project-type detection in `ralph init`: scans CWD for `package.json`, `go.mod`, `Makefile`, `Cargo.toml` and suggests appropriate `build`/`test` defaults; verifies Makefile targets exist before suggesting them; presents numbered choices when multiple files are detected; user may pick by number or type a custom value (#123)
+- `test/init.bats` extended to cover all detection cases: each project file type, Makefile with/without targets, multiple-match numbered list, custom freeform entry, no-match blank default (#123)
 
 ### Changed
 - `ralph run` preflight now calls `ralph_doctor()` instead of the old ad-hoc checks; aborts with exit 1 if any hard failure is found (#118)

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -72,7 +72,12 @@ _ralph_init_prompt() {
     if [[ "$input" =~ ^[0-9]+$ ]] && (( input >= 1 && input <= count )); then
       _RALPH_READ_VALUE="${suggestions[$((input-1))]}"
     else
-      _RALPH_READ_VALUE="${input:-${suggestions[0]}}"
+      if [[ "$input" =~ ^[0-9]+$ ]]; then
+        # Out-of-range number — fall back to first suggestion
+        _RALPH_READ_VALUE="${suggestions[0]}"
+      else
+        _RALPH_READ_VALUE="${input:-${suggestions[0]}}"
+      fi
     fi
   fi
 }

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -5,6 +5,78 @@
 #
 # Expects SCRIPT_DIR to be set by the caller (ralph.sh or tests).
 
+# Detect project-type command suggestions for a given field ("build" or "test").
+# Scans INIT_SCAN_DIR if set, otherwise PWD. Prints one suggestion per line.
+_ralph_init_detect() {
+  local field="$1"
+  local scan_dir="${INIT_SCAN_DIR:-$PWD}"
+
+  if [[ -f "$scan_dir/package.json" ]]; then
+    [[ "$field" == "test" ]]  && echo "npm test"
+    [[ "$field" == "build" ]] && echo "npm run build"
+  fi
+
+  if [[ -f "$scan_dir/go.mod" ]]; then
+    [[ "$field" == "test" ]]  && echo "go test ./..."
+    [[ "$field" == "build" ]] && echo "go build ./..."
+  fi
+
+  if [[ -f "$scan_dir/Makefile" ]]; then
+    if [[ "$field" == "test" ]] && grep -q "^test:" "$scan_dir/Makefile"; then
+      echo "make test"
+    fi
+    if [[ "$field" == "build" ]] && grep -q "^build:" "$scan_dir/Makefile"; then
+      echo "make build"
+    fi
+  fi
+
+  if [[ -f "$scan_dir/Cargo.toml" ]]; then
+    [[ "$field" == "test" ]]  && echo "cargo test"
+    [[ "$field" == "build" ]] && echo "cargo build"
+  fi
+}
+
+# Prompt the user for a command field with optional detected suggestions.
+# Suggestions are passed as positional args after label and desc.
+# Sets global _RALPH_READ_VALUE to the resolved input.
+_RALPH_READ_VALUE=""
+_ralph_init_prompt() {
+  local label="$1"
+  local desc="$2"
+  shift 2
+  local suggestions=("$@")
+  local count="${#suggestions[@]}"
+  local input=""
+
+  echo ""
+
+  if [[ $count -eq 0 ]]; then
+    echo "  $label  $desc []"
+    printf "  > "
+    read -r input
+    _RALPH_READ_VALUE="$input"
+  elif [[ $count -eq 1 ]]; then
+    echo "  $label  $desc [${suggestions[0]}]"
+    printf "  > "
+    read -r input
+    _RALPH_READ_VALUE="${input:-${suggestions[0]}}"
+  else
+    echo "  $label  $desc"
+    local i
+    for (( i=0; i<count; i++ )); do
+      echo "    $((i+1))) ${suggestions[$i]}"
+    done
+    echo "    Or type a custom value. []"
+    printf "  > "
+    read -r input
+    if [[ "$input" =~ ^[0-9]+$ ]] && (( input >= 1 && input <= count )); then
+      _RALPH_READ_VALUE="${suggestions[$((input-1))]}"
+    else
+      _RALPH_READ_VALUE="${input:-${suggestions[0]}}"
+    fi
+  fi
+}
+
 ralph_init() {
   local rule="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo "$rule"
@@ -46,19 +118,21 @@ ralph_init() {
 
   # ── Field 3: build ───────────────────────────────────────────────────────────
 
-  echo ""
-  echo "  build  Build command — leave empty if no build step. []"
-  printf "  > "
-  local build_value
-  read -r build_value
+  local -a _build_sugs=()
+  while IFS= read -r _line; do [[ -n "$_line" ]] && _build_sugs+=("$_line"); done \
+    < <(_ralph_init_detect "build")
+  _ralph_init_prompt "build" "Build command — leave empty if no build step." \
+    "${_build_sugs[@]+"${_build_sugs[@]}"}"
+  local build_value="$_RALPH_READ_VALUE"
 
   # ── Field 4: test ────────────────────────────────────────────────────────────
 
-  echo ""
-  echo "  test  Test command — required for Ralph to validate changes. []"
-  printf "  > "
-  local test_value
-  read -r test_value
+  local -a _test_sugs=()
+  while IFS= read -r _line; do [[ -n "$_line" ]] && _test_sugs+=("$_line"); done \
+    < <(_ralph_init_detect "test")
+  _ralph_init_prompt "test" "Test command — required for Ralph to validate changes." \
+    "${_test_sugs[@]+"${_test_sugs[@]}"}"
+  local test_value="$_RALPH_READ_VALUE"
 
   # ── Sanitize values for TOML string interpolation (escape \ then ") ─────────
 

--- a/test/init.bats
+++ b/test/init.bats
@@ -19,6 +19,8 @@ setup() {
   export SCRIPT_DIR="$REPO_ROOT"
   export GIT_ROOT="$BATS_TEST_TMPDIR"
   export INIT_OUTPUT_DIR="$BATS_TEST_TMPDIR"
+  # Isolate project-file detection from the real working directory.
+  export INIT_SCAN_DIR="$BATS_TEST_TMPDIR"
 
   # Default mock: gh repo view returns owner/repo.
   unset MOCK_REPO_VIEW_RESPONSE MOCK_REPO_VIEW_EXIT || true
@@ -182,4 +184,144 @@ _run_init() {
   run "$REPO_ROOT/ralph.sh" init <<< "$(printf '%s\n' "" "" "" "" "n")"
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "Ralph"
+}
+
+# ─── Project-type detection: no match ────────────────────────────────────────
+
+@test "init: no project file → blank build/test defaults (no regression)" {
+  # INIT_SCAN_DIR is empty temp dir — no project files.
+  _run_init "" "" "" "" "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Project-type detection: package.json ────────────────────────────────────
+
+@test "init: package.json present → npm test offered as test default" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "npm test"
+}
+
+@test "init: package.json present → npm run build offered as build default" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "npm run build"
+}
+
+@test "init: package.json present, enter accepted → file written with npm commands" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  _run_init "" "" "" "" "Y"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "npm run build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "npm test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Project-type detection: go.mod ──────────────────────────────────────────
+
+@test "init: go.mod present → go test ./... offered as test default" {
+  echo 'module example.com/mymod' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "go test ./\.\.\."
+}
+
+@test "init: go.mod present, enter accepted → file written with go commands" {
+  echo 'module example.com/mymod' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "" "" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "go build ./..."' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "go test ./..."' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Project-type detection: Makefile ────────────────────────────────────────
+
+@test "init: Makefile with test: target → make test offered" {
+  printf 'test:\n\techo run tests\n' > "$BATS_TEST_TMPDIR/Makefile"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "make test"
+}
+
+@test "init: Makefile without test: target → make test NOT offered (blank default)" {
+  printf 'lint:\n\techo lint\n' > "$BATS_TEST_TMPDIR/Makefile"
+  _run_init "" "" "" "" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'test = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: Makefile with build: target → make build offered" {
+  printf 'build:\n\techo build\n' > "$BATS_TEST_TMPDIR/Makefile"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "make build"
+}
+
+@test "init: Makefile without build: target → make build NOT offered (blank default)" {
+  printf 'lint:\n\techo lint\n' > "$BATS_TEST_TMPDIR/Makefile"
+  _run_init "" "" "" "" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = ""' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Project-type detection: Cargo.toml ──────────────────────────────────────
+
+@test "init: Cargo.toml present → cargo test offered as test default" {
+  echo '[package]' > "$BATS_TEST_TMPDIR/Cargo.toml"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "cargo test"
+}
+
+@test "init: Cargo.toml present, enter accepted → file written with cargo commands" {
+  echo '[package]' > "$BATS_TEST_TMPDIR/Cargo.toml"
+  _run_init "" "" "" "" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "cargo build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "cargo test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+# ─── Multiple matches: numbered list presented ────────────────────────────────
+
+@test "init: multiple project files → numbered options shown for test" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "1)"
+  echo "$output" | grep -q "2)"
+}
+
+@test "init: multiple project files → user picks number → correct command written" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  # build: pick option 1 (npm run build), test: pick option 1 (npm test)
+  _run_init "" "" "1" "1" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "npm run build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "npm test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: multiple project files → user picks second option" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  # build: pick option 2 (go build ./...), test: pick option 2 (go test ./...)
+  _run_init "" "" "2" "2" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "go build ./..."' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "go test ./..."' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: multiple project files → user types custom value instead of picking number" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "pnpm build" "vitest run" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "pnpm build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "vitest run"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: multiple project files → 'Or type a custom value' shown in output" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "" "" "n"
+  echo "$output" | grep -q "custom"
 }

--- a/test/init.bats
+++ b/test/init.bats
@@ -325,3 +325,32 @@ _run_init() {
   _run_init "" "" "" "" "n"
   echo "$output" | grep -q "custom"
 }
+
+# ─── Multiple-choice edge cases: out-of-range numeric input ──────────────────
+
+@test "init: multiple project files → out-of-range number (999) falls back to first suggestion" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "999" "999" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "npm run build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "npm test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: multiple project files → boundary value '0' falls back to first suggestion" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "0" "0" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "npm run build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "npm test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: multiple project files → empty input defaults to first suggestion" {
+  echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+  echo 'module example.com/m' > "$BATS_TEST_TMPDIR/go.mod"
+  _run_init "" "" "" "" "Y"
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'build = "npm run build"' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "npm test"' "$BATS_TEST_TMPDIR/ralph.toml"
+}


### PR DESCRIPTION
Closes #123

## What was implemented

Extended `lib/init.sh` to detect the project type from files in CWD and suggest appropriate `build`/`test` command defaults in `ralph init`:

| File | Test suggestion | Build suggestion |
|---|---|---|
| `package.json` | `npm test` | `npm run build` |
| `go.mod` | `go test ./...` | `go build ./...` |
| `Makefile` | `make test` (if target exists) | `make build` (if target exists) |
| `Cargo.toml` | `cargo test` | `cargo build` |

**Single match** — default shown in brackets, Enter to accept:
```
  test  Test command — required for Ralph to validate changes. [npm test]
  >
```

**Multiple matches** — numbered list plus freeform option:
```
  test  Test command — required for Ralph to validate changes.
    1) npm test
    2) go test ./...
    Or type a custom value. []
  >
```
User picks by number or types any custom string.

**No match** — blank default (no regression from Slice 1).

### New helpers

- `_ralph_init_detect <field>` — scans `INIT_SCAN_DIR` (or `$PWD`) for project files and prints suggestions
- `_ralph_init_prompt <label> <desc> [suggestions...]` — renders the prompt and sets `$_RALPH_READ_VALUE`
- `INIT_SCAN_DIR` env var added so tests can isolate detection from the real working directory

### Tests

`test/init.bats` extended with 17 new cases covering all detection paths (each project type, Makefile with/without targets, multiple-match number selection, freeform custom input, no-match blank).

## Limitations / known rough edges

- Detection is non-recursive (CWD only) as specified.
- Makefile target detection uses a simple `grep -q "^target:"` — won't catch phony targets defined with a leading tab or alternate target syntax, but covers the common case.
