### PR TITLE
feat(init): overwrite prompt and non-standard key preservation (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `test/init.bats`: bats tests covering all-defaults accepted, user overrides, blank upstream, declined preview, file comments, repo inference, and doctor call (#122)
 - Project-type detection in `ralph init`: scans CWD for `package.json`, `go.mod`, `Makefile`, `Cargo.toml` and suggests appropriate `build`/`test` defaults; verifies Makefile targets exist before suggesting them; presents numbered choices when multiple files are detected; user may pick by number or type a custom value (#123)
 - `test/init.bats` extended to cover all detection cases: each project file type, Makefile with/without targets, multiple-match numbered list, custom freeform entry, no-match blank default (#123)
+- `ralph init` pre-prompt overwrite check: when `ralph.toml` already exists, asks `ralph.toml already exists. Overwrite? [y/N]` before showing any prompts; default is No; declining exits cleanly without modifying the file (#124)
+- Non-standard key preservation in `ralph init`: when overwriting an existing `ralph.toml`, any keys not in the standard set (`repo`, `upstream`, `build`, `test`) are carried over to the new file after the standard fields, each preceded by a `# (preserved from previous ralph.toml)` comment (#124)
+- `test/init.bats` extended to cover all overwrite and preservation cases: decline with `n`, decline with Enter (default No), accept with `y`, single non-standard key preserved, multiple non-standard keys preserved, preserved keys appear after standard fields (#124)
 
 ### Changed
 - `ralph run` preflight now calls `ralph_doctor()` instead of the old ad-hoc checks; aborts with exit 1 if any hard failure is found (#118)

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -105,7 +105,7 @@ ralph_init() {
     while IFS= read -r _raw_line; do
       [[ "$_raw_line" =~ ^[[:space:]]*# ]] && continue
       [[ -z "${_raw_line// }" ]] && continue
-      if [[ "$_raw_line" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*= ]]; then
+      if [[ "$_raw_line" =~ ^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*= ]]; then
         local _pkey="${BASH_REMATCH[1]}"
         if ! [[ "$_pkey" =~ ^(repo|upstream|build|test)$ ]]; then
           _preserved_lines+=("$_raw_line")

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -83,6 +83,39 @@ _ralph_init_prompt() {
 }
 
 ralph_init() {
+  # ── Determine output path early (needed for overwrite check) ─────────────────
+
+  local output_path="${INIT_OUTPUT_DIR:-$GIT_ROOT}/ralph.toml"
+
+  # ── Overwrite prompt — runs before the prompt sequence ───────────────────────
+
+  local -a _preserved_lines=()
+
+  if [[ -f "$output_path" ]]; then
+    printf "ralph.toml already exists. Overwrite? [y/N] "
+    local overwrite_input
+    read -r overwrite_input
+    if [[ ! "$overwrite_input" =~ ^[Yy]$ ]]; then
+      echo ""
+      echo "  Aborted. No changes made."
+      return 0
+    fi
+
+    # Collect non-standard key=value lines from the existing file.
+    while IFS= read -r _raw_line; do
+      [[ "$_raw_line" =~ ^[[:space:]]*# ]] && continue
+      [[ -z "${_raw_line// }" ]] && continue
+      if [[ "$_raw_line" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)[[:space:]]*= ]]; then
+        local _pkey="${BASH_REMATCH[1]}"
+        if ! [[ "$_pkey" =~ ^(repo|upstream|build|test)$ ]]; then
+          _preserved_lines+=("$_raw_line")
+        fi
+      fi
+    done < "$output_path"
+  fi
+
+  # ── Header ───────────────────────────────────────────────────────────────────
+
   local rule="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo "$rule"
   echo "🚀 Ralph — init"
@@ -194,21 +227,13 @@ TOML
 
   # ── Write file ───────────────────────────────────────────────────────────────
 
-  local output_path="${INIT_OUTPUT_DIR:-$GIT_ROOT}/ralph.toml"
-
-  if [[ -f "$output_path" ]]; then
-    echo ""
-    printf "  ⚠️  %s already exists. Overwrite? [y/N] " "$output_path"
-    local overwrite_value
-    read -r overwrite_value
-    if [[ ! "$overwrite_value" =~ ^[Yy]$ ]]; then
-      echo ""
-      echo "  Aborted. Existing file kept."
-      return 0
-    fi
-  fi
-
-  printf '%s\n' "$file_contents" > "$output_path"
+  {
+    printf '%s\n' "$file_contents"
+    local _i
+    for (( _i=0; _i<${#_preserved_lines[@]}; _i++ )); do
+      printf '\n# (preserved from previous ralph.toml)\n%s\n' "${_preserved_lines[$_i]}"
+    done
+  } > "$output_path"
 
   echo ""
   echo "  ✅  Written: $output_path"

--- a/test/init.bats
+++ b/test/init.bats
@@ -218,6 +218,15 @@ _run_init() {
   grep -c '# (preserved from previous ralph.toml)' "$BATS_TEST_TMPDIR/ralph.toml" | grep -q "2"
 }
 
+@test "init: existing ralph.toml with indented non-standard key → key preserved on overwrite" {
+  printf 'repo = "old/repo"\nupstream = ""\nbuild = ""\ntest = ""\n  indented_key = "indented_val"\n' \
+    > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "y" "" "" "" "" "Y")"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'indented_key' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
 @test "init: preserved keys appear after standard fields in written file" {
   printf 'repo = "old/repo"\nupstream = ""\nbuild = ""\ntest = ""\ncustom_key = "custom_val"\n' \
     > "$BATS_TEST_TMPDIR/ralph.toml"

--- a/test/init.bats
+++ b/test/init.bats
@@ -151,22 +151,87 @@ _run_init() {
 }
 
 # ─── Overwrite protection ─────────────────────────────────────────────────────
+# Overwrite prompt now appears BEFORE the prompt sequence.
+# stdin order: overwrite → repo → upstream → build → test → write-confirm
 
 @test "init: existing ralph.toml → warns user, keeps file if declined" {
   echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
-  run ralph_init <<< "$(printf '%s\n' "" "" "" "" "Y" "n")"
+  run ralph_init <<< "$(printf '%s\n' "n" "" "" "" "" "Y")"
   [ "$status" -eq 0 ]
   grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
   echo "$output" | grep -q "already exists"
 }
 
-@test "init: existing ralph.toml → overwrites when user confirms" {
+@test "init: existing ralph.toml → user types n → file unchanged, clean exit" {
   echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
-  run ralph_init <<< "$(printf '%s\n' "" "" "" "" "Y" "y")"
+  run ralph_init <<< "$(printf '%s\n' "n")"
+  [ "$status" -eq 0 ]
+  grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
+  echo "$output" | grep -q "Aborted"
+}
+
+@test "init: existing ralph.toml → Enter (default No) → file unchanged, clean exit" {
+  echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "")"
+  [ "$status" -eq 0 ]
+  grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
+  echo "$output" | grep -q "Aborted"
+}
+
+@test "init: existing ralph.toml → user types y → full prompt sequence, file overwritten" {
+  echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "y" "" "" "" "" "Y")"
   [ "$status" -eq 0 ]
   [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
   ! grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
   grep -q 'repo = "' "$BATS_TEST_TMPDIR/ralph.toml"
+  echo "$output" | grep -q "Ralph"
+}
+
+@test "init: existing ralph.toml → overwrites when user confirms" {
+  echo "# existing" > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "y" "" "" "" "" "Y")"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  ! grep -q "# existing" "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'repo = "' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: existing ralph.toml with non-standard key → key preserved with comment on overwrite" {
+  printf 'repo = "old/repo"\nupstream = ""\nbuild = ""\ntest = ""\npermanent_issue = 1\n' \
+    > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "y" "" "" "" "" "Y")"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q '# (preserved from previous ralph.toml)' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'permanent_issue' "$BATS_TEST_TMPDIR/ralph.toml"
+}
+
+@test "init: existing ralph.toml with multiple non-standard keys → all preserved" {
+  printf 'repo = "old/repo"\nupstream = ""\nbuild = ""\ntest = ""\nalpha = "a"\nbeta = "b"\n' \
+    > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "y" "" "" "" "" "Y")"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  grep -q 'alpha' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'beta' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -c '# (preserved from previous ralph.toml)' "$BATS_TEST_TMPDIR/ralph.toml" | grep -q "2"
+}
+
+@test "init: preserved keys appear after standard fields in written file" {
+  printf 'repo = "old/repo"\nupstream = ""\nbuild = ""\ntest = ""\ncustom_key = "custom_val"\n' \
+    > "$BATS_TEST_TMPDIR/ralph.toml"
+  run ralph_init <<< "$(printf '%s\n' "y" "" "" "" "" "Y")"
+  [ "$status" -eq 0 ]
+  [ -f "$BATS_TEST_TMPDIR/ralph.toml" ]
+  # Standard fields must be present
+  grep -q 'repo = "' "$BATS_TEST_TMPDIR/ralph.toml"
+  grep -q 'test = "' "$BATS_TEST_TMPDIR/ralph.toml"
+  # Preserved key must appear after test field
+  local test_line custom_line
+  test_line=$(grep -n 'test = "' "$BATS_TEST_TMPDIR/ralph.toml" | head -1 | cut -d: -f1)
+  custom_line=$(grep -n 'custom_key' "$BATS_TEST_TMPDIR/ralph.toml" | head -1 | cut -d: -f1)
+  [ "$custom_line" -gt "$test_line" ]
 }
 
 # ─── ralph_doctor called after successful write ───────────────────────────────


### PR DESCRIPTION
Closes #124

## What was implemented

- **Pre-prompt overwrite check**: when `ralph.toml` already exists at the project root, `ralph init` now asks `ralph.toml already exists. Overwrite? [y/N]` _before_ showing any prompts. The default answer is No — pressing Enter exits cleanly without touching the file.
- **Non-standard key preservation**: when the user confirms an overwrite, any keys in the existing file that are not in the standard set (`repo`, `upstream`, `build`, `test`) are appended to the new file after the standard fields, each preceded by a `# (preserved from previous ralph.toml)` comment. Key–value lines are preserved verbatim (same format as found in the original file).
- **Removed old post-prompt guard**: the previous overwrite check (which appeared at the end, after the full prompt sequence) has been replaced by the new pre-prompt check.
- **New tests** (7 added, 2 existing overwrite tests updated to reflect the new prompt order):
  - Decline with `n` → file unchanged, clean exit
  - Decline with Enter (default No) → file unchanged, clean exit
  - Accept with `y` → full prompt sequence runs, file overwritten
  - Single non-standard key preserved with comment
  - Multiple non-standard keys all preserved
  - Preserved keys appear after standard fields
  - Overwrite confirmed → file rewritten correctly

## Limitations / known rough edges

- Values in the preserved lines are carried over exactly as they appear in the original file (verbatim line copy). If the original had an unquoted integer (`permanent_issue = 1`), it is preserved as-is rather than re-quoted — this keeps the TOML valid and avoids silently changing types.
- Only top-level `key = value` lines are scanned; TOML sections (`[section]`) are not currently handled (none are used by Ralph's config format).
