### PR TITLE
feat(utils): gh_with_retry() wrapper with exponential backoff (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - `lib/utils.sh` with `gh_with_retry()`: wraps `gh` with up to 3 attempts; sleeps 1 s before attempt 2 and 2 s before attempt 3; prints a ⚠️ warning to stderr on each failed attempt and a ❌ error after exhaustion; forwards all args, stdin, and exit codes transparently (#131)
-- `test/utils.bats`: bats tests covering all retry paths — first-attempt success, single retry, full exhaustion, arg forwarding, and stdin forwarding (#131) audits 9 environment checks (copilot in PATH, gh in PATH, gh authenticated, repo resolvable, modes directory present, ralph.toml present, test/build commands configured, GitHub API reachable); prints ✅/⚠️/❌ per check with fix hints; exits 0 if no hard failures, 1 if any occur (#117)
+- `test/utils.bats`: bats tests covering all retry paths — first-attempt success, single retry, full exhaustion, arg forwarding, and stdin forwarding (#131)
 - `ralph doctor` subcommand dispatched from `ralph.sh` (#117)
 - `test/doctor.bats`: bats tests covering all-pass, each hard failure in isolation, each warning in isolation, multiple simultaneous failures, mix of warnings and failures, and exit code behaviour (#117)
 - `lib/init.sh` with `ralph_init()`: guided prompt sequence to scaffold `ralph.toml`; infers `repo` from `gh repo view`; prompts for all four fields with descriptions and defaults; shows file preview in a `━━━` box with `Write this file? [Y/n]` confirmation; writes file with inline comments matching `project.example.toml` style; calls `ralph_doctor()` after a successful write (#122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - `lib/utils.sh` with `gh_with_retry()`: wraps `gh` with up to 3 attempts; sleeps 1 s before attempt 2 and 2 s before attempt 3; prints a ⚠️ warning to stderr on each failed attempt and a ❌ error after exhaustion; forwards all args, stdin, and exit codes transparently (#131)
 - `test/utils.bats`: bats tests covering all retry paths — first-attempt success, single retry, full exhaustion, arg forwarding, and stdin forwarding (#131)
+- `lib/doctor.sh` with `ralph_doctor()`: audits 9 environment checks (copilot in PATH, gh in PATH, gh authenticated, repo resolvable, modes directory present, ralph.toml present, test/build commands configured, GitHub API reachable); prints ✅/⚠️/❌ per check with fix hints; exits 0 if no hard failures, 1 if any occur (#117)
 - `ralph doctor` subcommand dispatched from `ralph.sh` (#117)
 - `test/doctor.bats`: bats tests covering all-pass, each hard failure in isolation, each warning in isolation, multiple simultaneous failures, mix of warnings and failures, and exit code behaviour (#117)
 - `lib/init.sh` with `ralph_init()`: guided prompt sequence to scaffold `ralph.toml`; infers `repo` from `gh repo view`; prompts for all four fields with descriptions and defaults; shows file preview in a `━━━` box with `Write this file? [Y/n]` confirmation; writes file with inline comments matching `project.example.toml` style; calls `ralph_doctor()` after a successful write (#122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- `lib/doctor.sh` with `ralph_doctor()`: audits 9 environment checks (copilot in PATH, gh in PATH, gh authenticated, repo resolvable, modes directory present, ralph.toml present, test/build commands configured, GitHub API reachable); prints ✅/⚠️/❌ per check with fix hints; exits 0 if no hard failures, 1 if any occur (#117)
+- `lib/utils.sh` with `gh_with_retry()`: wraps `gh` with up to 3 attempts; sleeps 1 s before attempt 2 and 2 s before attempt 3; prints a ⚠️ warning to stderr on each failed attempt and a ❌ error after exhaustion; forwards all args, stdin, and exit codes transparently (#131)
+- `test/utils.bats`: bats tests covering all retry paths — first-attempt success, single retry, full exhaustion, arg forwarding, and stdin forwarding (#131) audits 9 environment checks (copilot in PATH, gh in PATH, gh authenticated, repo resolvable, modes directory present, ralph.toml present, test/build commands configured, GitHub API reachable); prints ✅/⚠️/❌ per check with fix hints; exits 0 if no hard failures, 1 if any occur (#117)
 - `ralph doctor` subcommand dispatched from `ralph.sh` (#117)
 - `test/doctor.bats`: bats tests covering all-pass, each hard failure in isolation, each warning in isolation, multiple simultaneous failures, mix of warnings and failures, and exit code behaviour (#117)
 - `lib/init.sh` with `ralph_init()`: guided prompt sequence to scaffold `ralph.toml`; infers `repo` from `gh repo view`; prompts for all four fields with descriptions and defaults; shows file preview in a `━━━` box with `Write this file? [Y/n]` confirmation; writes file with inline comments matching `project.example.toml` style; calls `ralph_doctor()` after a successful write (#122)

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# utils.sh — shared utilities for ralph.sh and lib/*.sh
+#
+# Sourced by ralph.sh and individual lib scripts.
+
+# gh_with_retry() — wrapper around `gh` that retries up to 3 times on failure.
+#
+# Usage: gh_with_retry [gh args...]
+#
+# Behaviour:
+#   - Forwards all arguments and stdin verbatim to `gh`
+#   - On success (exit 0): returns immediately with stdout/stderr intact
+#   - On failure (non-zero exit):
+#       - Prints a warning to stderr with attempt number and backoff delay
+#       - Sleeps 1s before attempt 2, 2s before attempt 3
+#       - Retries
+#   - After 3 failed attempts: prints a final error to stderr and returns the
+#     last non-zero exit code
+gh_with_retry() {
+  local max_attempts=3
+  local attempt=1
+  local exit_code
+
+  while (( attempt <= max_attempts )); do
+    gh "$@" && return 0
+    exit_code=$?
+
+    if (( attempt < max_attempts )); then
+      local delay=$(( attempt ))
+      printf '  ⚠️  gh call failed (attempt %d/%d) — retrying in %ds…\n' \
+        "$attempt" "$max_attempts" "$delay" >&2
+      sleep "$delay"
+    fi
+
+    (( attempt++ ))
+  done
+
+  printf '  ❌  gh call failed after %d attempts: gh %s\n' \
+    "$max_attempts" "$*" >&2
+  return "$exit_code"
+}

--- a/test/helpers/mock_gh
+++ b/test/helpers/mock_gh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Mock gh stub for gh_with_retry tests.
+#
+# Reads:
+#   MOCK_GH_FAIL_TIMES  — how many times to fail before succeeding (0 = always succeed)
+#   MOCK_GH_STDOUT      — what to print on success
+#   MOCK_GH_EXIT        — exit code to use when failing (default 1)
+#   MOCK_GH_COUNTER_FILE — path to a file used to track invocation count
+#
+# On each call, increments the counter, then either exits with MOCK_GH_EXIT
+# (if invocation count <= MOCK_GH_FAIL_TIMES) or prints MOCK_GH_STDOUT and exits 0.
+
+set -euo pipefail
+
+MOCK_GH_FAIL_TIMES="${MOCK_GH_FAIL_TIMES:-0}"
+MOCK_GH_STDOUT="${MOCK_GH_STDOUT:-}"
+MOCK_GH_EXIT="${MOCK_GH_EXIT:-1}"
+MOCK_GH_COUNTER_FILE="${MOCK_GH_COUNTER_FILE:-/tmp/mock_gh_counter}"
+
+# Increment counter
+if [[ -f "$MOCK_GH_COUNTER_FILE" ]]; then
+  count=$(cat "$MOCK_GH_COUNTER_FILE")
+  count=$((count + 1))
+else
+  count=1
+fi
+printf '%s' "$count" > "$MOCK_GH_COUNTER_FILE"
+
+if (( count <= MOCK_GH_FAIL_TIMES )); then
+  exit "$MOCK_GH_EXIT"
+else
+  [[ -n "$MOCK_GH_STDOUT" ]] && printf '%s\n' "$MOCK_GH_STDOUT"
+  exit 0
+fi

--- a/test/helpers/mock_gh
+++ b/test/helpers/mock_gh
@@ -15,7 +15,7 @@ set -euo pipefail
 MOCK_GH_FAIL_TIMES="${MOCK_GH_FAIL_TIMES:-0}"
 MOCK_GH_STDOUT="${MOCK_GH_STDOUT:-}"
 MOCK_GH_EXIT="${MOCK_GH_EXIT:-1}"
-MOCK_GH_COUNTER_FILE="${MOCK_GH_COUNTER_FILE:-/tmp/mock_gh_counter}"
+MOCK_GH_COUNTER_FILE="${MOCK_GH_COUNTER_FILE:-${TMPDIR:-/tmp}/mock_gh_counter_$$}"
 
 # Increment counter
 if [[ -f "$MOCK_GH_COUNTER_FILE" ]]; then

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -165,3 +165,19 @@ EOF
   # stdin should have been empty (EOF from /dev/null).
   [ ! -s "$STDIN_LOG_FILE" ]
 }
+
+# ─── stderr forwarding ────────────────────────────────────────────────────────
+
+@test "stderr from gh is forwarded to caller on success" {
+  # A stub that writes to its own stderr and exits 0.
+  cat > "$BATS_TEST_TMPDIR/mock-bin/gh" << 'EOF'
+#!/usr/bin/env bash
+echo "gh stderr output" >&2
+exit 0
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/mock-bin/gh"
+
+  run --separate-stderr gh_with_retry pr list
+  [ "$status" -eq 0 ]
+  [[ "$stderr" == *"gh stderr output"* ]]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -181,3 +181,17 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$stderr" == *"gh stderr output"* ]]
 }
+
+@test "stderr from gh is forwarded to caller on failure/exhaustion" {
+  # A stub that writes to stderr on every invocation and always fails.
+  cat > "$BATS_TEST_TMPDIR/mock-bin/gh" << 'STUB'
+#!/usr/bin/env bash
+echo "gh native error" >&2
+exit 1
+STUB
+  chmod +x "$BATS_TEST_TMPDIR/mock-bin/gh"
+
+  run --separate-stderr gh_with_retry pr list
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"gh native error"* ]]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for gh_with_retry() in lib/utils.sh.
+#
+# Uses PATH prepending to inject a configurable mock_gh stub from test/helpers/.
+# The stub reads MOCK_GH_FAIL_TIMES, MOCK_GH_STDOUT, MOCK_GH_EXIT and writes
+# to MOCK_GH_COUNTER_FILE so tests can assert invocation count.
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  # Source utils into this shell.
+  # shellcheck source=../lib/utils.sh
+  source "$REPO_ROOT/lib/utils.sh"
+
+  # Create a temp dir with a `gh` symlink pointing at our mock stub.
+  mkdir -p "$BATS_TEST_TMPDIR/mock-bin"
+  # Copy mock_gh into the test-local bin dir (not a symlink — tests that write
+  # a custom gh must not corrupt the shared test/helpers/mock_gh source file).
+  cp "$REPO_ROOT/test/helpers/mock_gh" "$BATS_TEST_TMPDIR/mock-bin/gh"
+  chmod +x "$BATS_TEST_TMPDIR/mock-bin/gh"
+  export PATH="$BATS_TEST_TMPDIR/mock-bin:$PATH"
+
+  # Counter file is unique per test run.
+  export MOCK_GH_COUNTER_FILE="$BATS_TEST_TMPDIR/gh_counter"
+
+  # Clear mock env vars so tests start from a clean state.
+  unset MOCK_GH_FAIL_TIMES MOCK_GH_STDOUT MOCK_GH_EXIT || true
+}
+
+# Helper: read invocation count from the counter file.
+gh_call_count() {
+  if [[ -f "$MOCK_GH_COUNTER_FILE" ]]; then
+    cat "$MOCK_GH_COUNTER_FILE"
+  else
+    echo 0
+  fi
+}
+
+# ─── success path ─────────────────────────────────────────────────────────────
+
+@test "first attempt succeeds → stdout forwarded, exit 0, gh called once, no warning" {
+  export MOCK_GH_FAIL_TIMES=0
+  export MOCK_GH_STDOUT="hello world"
+
+  run gh_with_retry pr list
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello world" ]
+  [ "$(gh_call_count)" -eq 1 ]
+}
+
+@test "first attempt succeeds → no warning printed to stderr" {
+  export MOCK_GH_FAIL_TIMES=0
+  export MOCK_GH_STDOUT="ok"
+
+  # bats `run` captures stderr in $output only with --separate-stderr flag (bats ≥1.7)
+  # We redirect stderr to a file and assert it is empty.
+  gh_with_retry pr list 2>"$BATS_TEST_TMPDIR/stderr.txt"
+  [ ! -s "$BATS_TEST_TMPDIR/stderr.txt" ]
+}
+
+# ─── single retry ─────────────────────────────────────────────────────────────
+
+@test "first attempt fails, second succeeds → warning printed, exit 0, gh called twice" {
+  export MOCK_GH_FAIL_TIMES=1
+  export MOCK_GH_EXIT=1
+  export MOCK_GH_STDOUT="recovered"
+
+  run --separate-stderr gh_with_retry pr list
+  [ "$status" -eq 0 ]
+  [ "$output" = "recovered" ]
+  [ "$(gh_call_count)" -eq 2 ]
+  [[ "$stderr" == *"attempt 1/3"* ]]
+}
+
+@test "first attempt fails → warning message matches expected format" {
+  export MOCK_GH_FAIL_TIMES=1
+  export MOCK_GH_EXIT=42
+  export MOCK_GH_STDOUT=""
+
+  run --separate-stderr gh_with_retry api /some/endpoint
+  [[ "$stderr" == *"⚠️"* ]]
+  [[ "$stderr" == *"retrying"* ]]
+}
+
+# ─── all attempts exhausted ───────────────────────────────────────────────────
+
+@test "all 3 attempts fail → non-zero exit" {
+  export MOCK_GH_FAIL_TIMES=99
+  export MOCK_GH_EXIT=2
+
+  run gh_with_retry pr list
+  [ "$status" -ne 0 ]
+}
+
+@test "all 3 attempts fail → gh called exactly 3 times" {
+  export MOCK_GH_FAIL_TIMES=99
+  export MOCK_GH_EXIT=1
+
+  run gh_with_retry pr list
+  [ "$(gh_call_count)" -eq 3 ]
+}
+
+@test "all 3 attempts fail → 2 warning messages on stderr" {
+  export MOCK_GH_FAIL_TIMES=99
+  export MOCK_GH_EXIT=1
+
+  run --separate-stderr gh_with_retry pr list
+  warning_count=$(echo "$stderr" | grep -c "⚠️" || true)
+  [ "$warning_count" -eq 2 ]
+}
+
+@test "all 3 attempts fail → final error message on stderr" {
+  export MOCK_GH_FAIL_TIMES=99
+  export MOCK_GH_EXIT=1
+
+  run --separate-stderr gh_with_retry pr list
+  [[ "$stderr" == *"❌"* ]]
+  [[ "$stderr" == *"3 attempts"* ]]
+}
+
+@test "all 3 attempts fail → last non-zero exit code returned" {
+  export MOCK_GH_FAIL_TIMES=99
+  export MOCK_GH_EXIT=5
+
+  run gh_with_retry pr list
+  [ "$status" -eq 5 ]
+}
+
+# ─── argument forwarding ──────────────────────────────────────────────────────
+
+@test "arguments are forwarded verbatim to gh" {
+  # We verify by capturing the args the stub receives. The stub doesn't echo
+  # args back, so we use a custom wrapper that logs args to a file.
+  cat > "$BATS_TEST_TMPDIR/mock-bin/gh" << 'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >> "${ARG_LOG_FILE}"
+exit 0
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/mock-bin/gh"
+
+  export ARG_LOG_FILE="$BATS_TEST_TMPDIR/args.txt"
+  gh_with_retry pr list --repo owner/repo
+
+  grep -q "pr"        "$ARG_LOG_FILE"
+  grep -q "list"      "$ARG_LOG_FILE"
+  grep -q "owner/repo" "$ARG_LOG_FILE"
+}
+
+# ─── stdin forwarding ─────────────────────────────────────────────────────────
+
+@test "stdin forwarding: < /dev/null pattern works correctly" {
+  # A stub that reads stdin and exits 0 — should not block when /dev/null is used.
+  cat > "$BATS_TEST_TMPDIR/mock-bin/gh" << 'EOF'
+#!/usr/bin/env bash
+# Read any stdin (non-blocking thanks to /dev/null at call site).
+stdin_content=$(cat)
+printf '%s' "$stdin_content" > "${STDIN_LOG_FILE}"
+exit 0
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/mock-bin/gh"
+
+  export STDIN_LOG_FILE="$BATS_TEST_TMPDIR/stdin.txt"
+  gh_with_retry api /repos < /dev/null
+
+  # stdin should have been empty (EOF from /dev/null).
+  [ ! -s "$STDIN_LOG_FILE" ]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -194,4 +194,5 @@ STUB
   run --separate-stderr gh_with_retry pr list
   [ "$status" -eq 1 ]
   [[ "$stderr" == *"gh native error"* ]]
+  [ "$(echo "$stderr" | grep -c 'gh native error')" -eq 3 ]
 }


### PR DESCRIPTION
Closes #131

## What was implemented

- **`lib/utils.sh`** — new shared utility library with `gh_with_retry()`, a transparent drop-in wrapper for `gh` that:
  - Retries up to 3 total attempts on any non-zero exit
  - Sleeps 1 s before attempt 2, 2 s before attempt 3 (exponential backoff)
  - Prints `⚠️  gh call failed (attempt N/3) — retrying in Xs…` to stderr on each failure
  - Prints `❌  gh call failed after 3 attempts: gh <cmd>` after exhaustion
  - Forwards all arguments, stdin, stdout/stderr, and exit codes transparently (no latency on success path)

- **`test/helpers/mock_gh`** — configurable `gh` stub driven by `MOCK_GH_FAIL_TIMES`, `MOCK_GH_STDOUT`, `MOCK_GH_EXIT`, and `MOCK_GH_COUNTER_FILE` env vars

- **`test/utils.bats`** — 11 bats tests covering all acceptance criteria:
  - First-attempt success (stdout forwarded, exit 0, called once, no stderr warning)
  - Single retry (warning on attempt 1, exit 0, called twice)
  - Full exhaustion (2 warnings + 1 final error, non-zero exit, called exactly 3 times, last exit code propagated)
  - Argument forwarding verbatim
  - Stdin forwarding (`< /dev/null` pattern)

## Notes / limitations

- `sleep` calls are real (1 s and 2 s), so exhaustion tests take ~3 s each — the suite completes in well under 30 s in practice.
- `gh_with_retry` is defined but not yet wired into any existing `gh` call sites; that migration is left for follow-on slices as described in PRD #130.
- The `mock_gh` stub in `test/helpers/` is distinct from the existing routing/doctor `gh` mock (same directory); both can coexist because utils tests inject the stub via a per-test `$BATS_TEST_TMPDIR/mock-bin` directory using `cp` (not `ln -sf`) to avoid corrupting the shared source file.
