### PR TITLE
feat(jira): --ticket flag and jira-cli doctor warnings (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- `ralph run --ticket=<KEY-N>` flag: parses JIRA-style ticket references (e.g. `CAPP-123`), exposes `PARENT_TICKET`, `PROJECT_KEY`, and `TASK_BACKEND=jira`; mutually exclusive with `--label` and `--issue`; stub-accepted by `ralph status` (#143)
+- `ralph doctor` jira-cli warning checks: emits a ⚠️ when jira-cli is missing or unauthenticated; only runs when `TASK_BACKEND=jira` so the default 9-check surface is unchanged (#143)
 - `ralph.sh` sources `lib/utils.sh` and uses `gh_with_retry` for every `gh` call site (#134)
 - `lib/routing.sh` now sources `lib/utils.sh` and uses `gh_with_retry` for all `gh` calls (#132)
 - `lib/utils.sh` with `gh_with_retry()`: wraps `gh` with up to 3 attempts; sleeps 1 s before attempt 2 and 2 s before attempt 3; prints a ⚠️ warning to stderr on each failed attempt and a ❌ error after exhaustion; forwards all args, stdin, and exit codes transparently (#131)

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -110,6 +110,28 @@ ralph_doctor() {
     fi
   fi
 
+  # ── JIRA backend warnings (only when TASK_BACKEND=jira) ────────────────────
+  # These are warnings, never hard failures: the GitHub path remains usable
+  # even if jira-cli is missing or unauthenticated.
+
+  if [[ "${TASK_BACKEND:-}" == "jira" ]]; then
+    # 10. jira-cli in PATH
+    if command -v jira >/dev/null 2>&1; then
+      echo "  ✅  jira-cli found in PATH"
+
+      # 11. jira-cli authenticated (uses `jira me` — fails when unauthenticated)
+      if jira me >/dev/null 2>&1; then
+        echo "  ✅  jira-cli is authenticated"
+      else
+        echo "  ⚠️   jira-cli is not authenticated"
+        echo "     → run jira init to authenticate"
+      fi
+    else
+      echo "  ⚠️   jira-cli not found in PATH"
+      echo "     → install jira-cli (https://github.com/ankitpokhrel/jira-cli)"
+    fi
+  fi
+
   echo ""
   if [[ "$hard_fail" -eq 0 ]]; then
     echo "  All checks passed."

--- a/ralph.sh
+++ b/ralph.sh
@@ -110,6 +110,7 @@ fi
 if [[ "$SUBCOMMAND" == "status" ]]; then
   FEATURE_LABEL=""
   FEATURE_BRANCH="main"
+  PARENT_TICKET=""
 
   for arg in "$@"; do
     if [[ "$arg" =~ ^--label=(.+)$ ]]; then
@@ -117,12 +118,22 @@ if [[ "$SUBCOMMAND" == "status" ]]; then
       FEATURE_BRANCH="feat/${BASH_REMATCH[1]}"
     elif [[ "$arg" =~ ^--ticket=([A-Z][A-Z0-9]*-[1-9][0-9]*)$ ]]; then
       # Stub-accept: JIRA backend wiring lands in a later slice.
-      :
+      PARENT_TICKET="${BASH_REMATCH[1]}"
+    elif [[ "$arg" =~ ^--ticket(=.*)?$ ]]; then
+      echo "Error: --ticket value must look like KEY-NUMBER (e.g. CAPP-123)."
+      echo "Usage: $(basename "$0") status [--label=<label>] [--ticket=<KEY-N>]"
+      exit 1
     else
       echo "Usage: $(basename "$0") status [--label=<label>] [--ticket=<KEY-N>]"
       exit 1
     fi
   done
+
+  # --ticket is mutually exclusive with --label (different task backends).
+  if [[ -n "$PARENT_TICKET" && -n "$FEATURE_LABEL" ]]; then
+    echo "Error: --ticket and --label are mutually exclusive (different task backends)."
+    exit 1
+  fi
 
   if [[ "${RALPH_PARSE_ONLY:-}" == "1" ]]; then
     echo "SUBCOMMAND=status"

--- a/ralph.sh
+++ b/ralph.sh
@@ -115,8 +115,11 @@ if [[ "$SUBCOMMAND" == "status" ]]; then
     if [[ "$arg" =~ ^--label=(.+)$ ]]; then
       FEATURE_LABEL="prd/${BASH_REMATCH[1]}"
       FEATURE_BRANCH="feat/${BASH_REMATCH[1]}"
+    elif [[ "$arg" =~ ^--ticket=([A-Z][A-Z0-9]*-[1-9][0-9]*)$ ]]; then
+      # Stub-accept: JIRA backend wiring lands in a later slice.
+      :
     else
-      echo "Usage: $(basename "$0") status [--label=<label>]"
+      echo "Usage: $(basename "$0") status [--label=<label>] [--ticket=<KEY-N>]"
       exit 1
     fi
   done
@@ -164,7 +167,7 @@ fi
 # ── Argument validation (run subcommand) ───────────────────────────────────────
 
 usage() {
-  echo "Usage: $(basename "$0") run [--max-iterations=N] [--label=<label>] [--issue=<N>]"
+  echo "Usage: $(basename "$0") run [--max-iterations=N] [--label=<label>] [--issue=<N>] [--ticket=<KEY-N>]"
   echo ""
   echo "  --max-iterations=N  Optional positive integer — how many Copilot iterations"
   echo "                      to allow before giving up. When omitted, Ralph runs"
@@ -179,17 +182,25 @@ usage() {
   echo "                      issue is merged, Ralph exits cleanly without opening a"
   echo "                      feature PR."
   echo ""
+  echo "  --ticket=<KEY-N>    Optional JIRA ticket reference (e.g. CAPP-123). Switches"
+  echo "                      Ralph's task backend to JIRA. Mutually exclusive with"
+  echo "                      --label and --issue."
+  echo ""
   echo "Examples:"
   echo "  $(basename "$0") run"
   echo "  $(basename "$0") run --label=foo-widget"
   echo "  $(basename "$0") run --max-iterations=20 --label=foo-widget"
   echo "  $(basename "$0") run --max-iterations=20 --issue=82 --label=foo-widget"
+  echo "  $(basename "$0") run --ticket=CAPP-123"
 }
 
 MAX_ITERATIONS=""
 FEATURE_LABEL=""
 FEATURE_BRANCH="main"
 PINNED_ISSUE=""
+PARENT_TICKET=""
+PROJECT_KEY=""
+TASK_BACKEND="github"
 
 for arg in "$@"; do
   if [[ "$arg" =~ ^[1-9][0-9]*$ ]]; then
@@ -205,11 +216,31 @@ for arg in "$@"; do
     FEATURE_BRANCH="feat/${BASH_REMATCH[1]}"
   elif [[ "$arg" =~ ^--issue=([1-9][0-9]*)$ ]]; then
     PINNED_ISSUE="${BASH_REMATCH[1]}"
+  elif [[ "$arg" =~ ^--ticket=([A-Z][A-Z0-9]*-[1-9][0-9]*)$ ]]; then
+    PARENT_TICKET="${BASH_REMATCH[1]}"
+    PROJECT_KEY="${PARENT_TICKET%%-*}"
+    TASK_BACKEND="jira"
+  elif [[ "$arg" =~ ^--ticket(=.*)?$ ]]; then
+    echo "Error: --ticket value must look like KEY-NUMBER (e.g. CAPP-123)."
+    usage
+    exit 1
   else
     usage
     exit 1
   fi
 done
+
+# --ticket is mutually exclusive with --label and --issue (different task backends).
+if [[ -n "$PARENT_TICKET" ]]; then
+  if [[ -n "$FEATURE_LABEL" ]]; then
+    echo "Error: --ticket and --label are mutually exclusive (different task backends)."
+    exit 1
+  fi
+  if [[ -n "$PINNED_ISSUE" ]]; then
+    echo "Error: --ticket and --issue are mutually exclusive (different task backends)."
+    exit 1
+  fi
+fi
 
 # Test hook: exit 0 after successful arg parsing so bats tests can verify
 # arg handling without requiring a full preflight environment.
@@ -217,8 +248,13 @@ if [[ "${RALPH_PARSE_ONLY:-}" == "1" ]]; then
   echo "MAX_ITERATIONS=${MAX_ITERATIONS}"
   echo "FEATURE_BRANCH=${FEATURE_BRANCH}"
   echo "PINNED_ISSUE=${PINNED_ISSUE}"
+  echo "PARENT_TICKET=${PARENT_TICKET}"
+  echo "PROJECT_KEY=${PROJECT_KEY}"
+  echo "TASK_BACKEND=${TASK_BACKEND}"
   exit 0
 fi
+
+export TASK_BACKEND PARENT_TICKET PROJECT_KEY
 
 # Derive the worktree path. Include the PRD slug when --label is set so
 # multiple ralph runs can coexist in parallel on the same machine.

--- a/test/arg-parsing.bats
+++ b/test/arg-parsing.bats
@@ -115,3 +115,67 @@ RALPH="$REPO_ROOT/ralph.sh"
   [ "$status" -eq 1 ]
   echo "$output" | grep -qi "usage\|--max-iterations"
 }
+
+# ─── run subcommand: --ticket flag (JIRA backend) ────────────────────────────
+
+@test "run --ticket=CAPP-123: parses successfully, exposes JIRA backend vars" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --ticket=CAPP-123
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "PARENT_TICKET=CAPP-123"
+  echo "$output" | grep -q "PROJECT_KEY=CAPP"
+  echo "$output" | grep -q "TASK_BACKEND=jira"
+}
+
+@test "run --ticket=PROJ-1: minimum-shape ticket accepted" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --ticket=PROJ-1
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "PARENT_TICKET=PROJ-1"
+  echo "$output" | grep -q "PROJECT_KEY=PROJ"
+  echo "$output" | grep -q "TASK_BACKEND=jira"
+}
+
+@test "run --ticket=invalid: exits with usage error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --ticket=not-a-ticket
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "usage\|--ticket"
+}
+
+@test "run --ticket without value: exits with usage error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --ticket
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -qi "usage\|--ticket"
+}
+
+@test "run --label only: TASK_BACKEND defaults to github" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --label=foo-widget
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "TASK_BACKEND=github"
+}
+
+@test "run with no flags: TASK_BACKEND defaults to github" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "TASK_BACKEND=github"
+}
+
+# ─── run subcommand: --ticket mutex ─────────────────────────────────────────
+
+@test "run --ticket + --label: exits non-zero with mutex error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --ticket=CAPP-123 --label=foo
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "mutually exclusive\|cannot.*combine\|--ticket.*--label\|mutex"
+}
+
+@test "run --ticket + --issue: exits non-zero with mutex error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" run --ticket=CAPP-123 --issue=42
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "mutually exclusive\|cannot.*combine\|--ticket.*--issue\|mutex"
+}
+
+# ─── status subcommand: --ticket flag (stub-accept) ──────────────────────────
+
+@test "status --ticket=CAPP-123: parses successfully (stub-accept)" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" status --ticket=CAPP-123
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "SUBCOMMAND=status"
+}

--- a/test/arg-parsing.bats
+++ b/test/arg-parsing.bats
@@ -33,6 +33,30 @@ RALPH="$REPO_ROOT/ralph.sh"
   echo "$output" | grep -qi "usage"
 }
 
+@test "status --ticket=<KEY-N>: exits 0" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" status --ticket=CAPP-123
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "SUBCOMMAND=status"
+}
+
+@test "status --label and --ticket together: exits non-zero with mutex error" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" status --label=foo --ticket=CAPP-123
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "mutually exclusive"
+}
+
+@test "status --ticket with invalid value: exits non-zero" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" status --ticket=not-a-ticket
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "usage\|KEY-NUMBER"
+}
+
+@test "status --ticket bare flag (no value): exits non-zero" {
+  run env RALPH_PARSE_ONLY=1 "$RALPH" status --ticket
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "usage\|KEY-NUMBER"
+}
+
 @test "run subcommand: exits 0" {
   run env RALPH_PARSE_ONLY=1 "$RALPH" run
   [ "$status" -eq 0 ]

--- a/test/doctor.bats
+++ b/test/doctor.bats
@@ -245,4 +245,46 @@ _make_bin() {
   echo "$output" | grep -q "🩺 Ralph — doctor"
 }
 
+# ─── jira-cli warning checks (only when TASK_BACKEND=jira) ───────────────────
+
+@test "doctor: TASK_BACKEND=jira + jira-cli absent → ⚠️ line and exit 0" {
+  export TASK_BACKEND=jira
+  # Hermetic bin without jira (only gh + copilot from helpers).
+  _make_bin gh copilot
+
+  run ralph_doctor
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "⚠️.*jira"
+  echo "$output" | grep -qi "→.*install"
+}
+
+@test "doctor: TASK_BACKEND=jira + jira-cli present + authed → ✅ line and exit 0" {
+  export TASK_BACKEND=jira
+  _make_bin gh copilot jira
+  export MOCK_JIRA_AUTH_EXIT=0
+
+  run ralph_doctor
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "✅.*jira"
+  echo "$output" | grep -qv "⚠️.*jira"
+}
+
+@test "doctor: TASK_BACKEND=jira + jira-cli present but unauthenticated → ⚠️ line and exit 0" {
+  export TASK_BACKEND=jira
+  _make_bin gh copilot jira
+  export MOCK_JIRA_AUTH_EXIT=1
+
+  run ralph_doctor
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "⚠️.*jira"
+  echo "$output" | grep -qi "→.*auth\|→.*login\|→.*jira init"
+}
+
+@test "doctor: TASK_BACKEND unset → no jira-cli check lines (9-check behaviour preserved)" {
+  unset TASK_BACKEND || true
+  run ralph_doctor
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qv "jira"
+}
+
 # ─── All checks pass ──────────────────────────────────────────────────────────

--- a/test/helpers/jira
+++ b/test/helpers/jira
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Mock jira-cli for bats tests.
+#
+# Reads response data from MOCK_* environment variables:
+#
+#   MOCK_JIRA_AUTH_EXIT  Non-zero to simulate unauthenticated `jira me` (default 0)
+
+if [[ "${1:-}" == "me" ]]; then
+  exit "${MOCK_JIRA_AUTH_EXIT:-0}"
+fi
+
+# Default: behave like a present, working binary for any other invocation.
+exit 0


### PR DESCRIPTION
Closes #143

## What this implements

The thinnest tracer for the JIRA backend — proves the new flag and doctor surface area exist without wiring any JIRA functionality yet. The GitHub path remains entirely unchanged.

### `ralph run --ticket=<KEY-N>`
- Parses JIRA-style ticket references (e.g. `CAPP-123`).
- Exposes `PARENT_TICKET=CAPP-123`, `PROJECT_KEY=CAPP`, `TASK_BACKEND=jira` under `RALPH_PARSE_ONLY=1`.
- Mutually exclusive with `--label` and `--issue` — clear error on conflict.
- Without `--ticket`, `TASK_BACKEND=github` is always emitted.
- Invalid shapes (e.g. `--ticket=not-a-ticket`, bare `--ticket`) exit non-zero with usage.

### `ralph status --ticket=<KEY-N>`
- Stub-accepted (parses without error). Functional behaviour lands in a later slice.

### `ralph doctor` jira-cli checks
- New warnings (never hard failures): jira-cli missing → ⚠️; jira-cli installed but unauthenticated (uses `jira me`) → ⚠️.
- Gated on `TASK_BACKEND=jira` so the default 9-check surface stays exactly as-is. The existing "exactly 9 status lines" test passes untouched.

## Tests
- `test/arg-parsing.bats`: 9 new tests covering happy path, mutex (`--ticket` + `--label`, `--ticket` + `--issue`), invalid shapes, default `TASK_BACKEND=github`, and status stub-accept.
- `test/doctor.bats`: 4 new tests covering the three jira-cli states and the unset-backend no-op.
- `test/helpers/jira`: mock binary respecting `MOCK_JIRA_AUTH_EXIT`.
- All 150 tests pass.

## Known rough edges
- `PARENT_TICKET` / `PROJECT_KEY` / `TASK_BACKEND` are exported but not yet consumed by routing or modes — that wiring lands in the next PRD slice.
- `ralph status --ticket=...` accepts but ignores the value. Functional JIRA status comes later.
